### PR TITLE
Feature/alpha visualization

### DIFF
--- a/geoimage/src/geoimage/README.md
+++ b/geoimage/src/geoimage/README.md
@@ -22,7 +22,7 @@
 ### Data processing options
 - `useAutoRange : boolean` - set automatic range of color gradient **(default false)**
 - `useDataForOpacity : boolean` - visualise data with opacity of each pixel according to its value **(default false)**
-- `alpha : number` - visualise entire image with specified opacity **(if useDataOpacity is false)** **(default 255)**
+- `alpha : number` - visualise entire image with specified opacity **(if useDataOpacity is false)**, values 0-100 **(default 100)**
 - `useHeatMap : boolean` - generate data as a color heatmap **(default true)**
  `useChannel : number | null` - specify a single channel to use **(default null)**
 - `multiplier : number  ` - multiplies each value **(default 1.00)**
@@ -85,14 +85,14 @@ const g = new GeoImage();
 //Single-channel geotiff as a transparent heatmap with auto-rage:
 g.useAutoRange(true);
 g.useHeatMap(true);
-g.alpha(120);
+g.alpha(100);
 const firstImage = await g.getMap("image", 'image.tif');
 
 //Single-channel geotiff as a transparent heatmap with manual range in meters:
 g.useAutoRange(false);
 g.useDataRange(0,250); //Blue at 0m, red at 250m
 g.useHeatMap(true);
-g.alpha(120);
+g.alpha(80);
 const secondImage = await g.getBitmap("image", 'image.tif');
 
 //Single-channel geotiff with data as transparency:

--- a/geoimage/src/geoimage/README.md
+++ b/geoimage/src/geoimage/README.md
@@ -22,7 +22,7 @@
 ### Data processing options
 - `useAutoRange : boolean` - set automatic range of color gradient **(default false)**
 - `useDataForOpacity : boolean` - visualise data with opacity of each pixel according to its value **(default false)**
-- `alpha : number` - visualise data in specific opacity **(if useDataOpacity is false)** **(default 150)**
+- `alpha : number` - visualise entire image with specified opacity **(if useDataOpacity is false)** **(default 255)**
 - `useHeatMap : boolean` - generate data as a color heatmap **(default true)**
  `useChannel : number | null` - specify a single channel to use **(default null)**
 - `multiplier : number  ` - multiplies each value **(default 1.00)**

--- a/geoimage/src/geoimage/geoimage.ts
+++ b/geoimage/src/geoimage/geoimage.ts
@@ -47,7 +47,7 @@ const DefaultGeoImageOptions: GeoImageOptions = {
   colorScale: chroma.brewer.YlOrRd,
   colorScaleValueRange: [0, 255],
   colorsBasedOnValues: null,
-  alpha: 255,
+  alpha: 100,
   useChannel: null,
   noDataValue: undefined,
   numOfChannels: undefined,
@@ -236,7 +236,7 @@ export default class GeoImage {
             const rgbColor = [rasters[0][pixel], rasters[0][pixel + 1], rasters[0][pixel + 2]];
             const rgbaColor = this.hasPixelsNoData(rgbColor, optionsLocal.noDataValue)
               ? optionsLocal.nullColor
-              : [...rgbColor, optionsLocal.alpha!];
+              : [...rgbColor, Math.floor(optionsLocal.alpha! * 2.55)];
             // eslint-disable-next-line max-len
             [imageData.data[idx], imageData.data[idx + 1], imageData.data[idx + 2], imageData.data[idx + 3]] = rgbaColor;
             pixel += 3;
@@ -256,7 +256,7 @@ export default class GeoImage {
           r = rasters[0][pixel];
           g = rasters[1][pixel];
           b = rasters[2][pixel];
-          a = optionsLocal.alpha!;
+          a = Math.floor(optionsLocal.alpha! * 2.55);
 
           imageData.data[i] = r;
           imageData.data[i + 1] = g;
@@ -273,7 +273,7 @@ export default class GeoImage {
           r = rasters[0][pixel];
           g = rasters[1][pixel];
           b = rasters[2][pixel];
-          a = optionsLocal.alpha!;
+          a = Math.floor(optionsLocal.alpha! * 2.55);
 
           imageData.data[i] = r;
           imageData.data[i + 1] = g;
@@ -333,7 +333,7 @@ export default class GeoImage {
 
     // for useColorsBasedOnValues
     const dataValues = options.colorsBasedOnValues ? options.colorsBasedOnValues.map(([first]) => first) : undefined;
-    const colorValues = options.colorsBasedOnValues ? options.colorsBasedOnValues.map(([, second]) => [...chroma(second).rgb(), options.alpha]) : undefined;
+    const colorValues = options.colorsBasedOnValues ? options.colorsBasedOnValues.map(([, second]) => [...chroma(second).rgb(), Math.floor(options.alpha * 2.55)]) : undefined;
 
     for (let i = 0; i < arrayLength; i += 4) {
       let pixelColor = options.nullColor;
@@ -347,7 +347,7 @@ export default class GeoImage {
           if (options.useHeatMap) {
             // FIXME
             // eslint-disable-next-line
-            pixelColor = [...colorScale(dataArray[pixel]).rgb(), 255];
+            pixelColor = [...colorScale(dataArray[pixel]).rgb(), Math.floor(options.alpha * 2.55)];
           }
           if (options.useColorsBasedOnValues) {
             const index = dataValues.indexOf(dataArray[pixel]);

--- a/geoimage/src/geoimage/geoimage.ts
+++ b/geoimage/src/geoimage/geoimage.ts
@@ -187,7 +187,6 @@ export default class GeoImage {
       width = input.width;
       height = input.height;
     }
-    // TO DO if alpha is set in options, then apply to entire image
 
     const canvas = document.createElement('canvas');
     canvas.width = width;
@@ -334,7 +333,7 @@ export default class GeoImage {
 
     // for useColorsBasedOnValues
     const dataValues = options.colorsBasedOnValues ? options.colorsBasedOnValues.map(([first]) => first) : undefined;
-    const colorValues = options.colorsBasedOnValues ? options.colorsBasedOnValues.map(([, second]) => [...chroma(second).rgb(), 255]) : undefined;
+    const colorValues = options.colorsBasedOnValues ? options.colorsBasedOnValues.map(([, second]) => [...chroma(second).rgb(), options.alpha]) : undefined;
 
     for (let i = 0; i < arrayLength; i += 4) {
       let pixelColor = options.nullColor;


### PR DESCRIPTION
Alpha range updated from 0-255 to 0-100, thus COG explorer should reflect these changes too when using alpha "Visualise data in specific opacity (if useDataOpacity is false) (default 150)". Value 150 should not be used anymore, maximum value is now 100.