### PR TITLE
Feature/terrain options update

### DIFF
--- a/geoimage/src/cogterrainlayer/CogTerrainLayer.ts
+++ b/geoimage/src/cogterrainlayer/CogTerrainLayer.ts
@@ -1,6 +1,6 @@
 import { CompositeLayer } from '@deck.gl/core';
 import { TileLayer, TerrainLayer } from '@deck.gl/geo-layers';
-import chroma from "chroma-js";
+import chroma from 'chroma-js';
 
 // FIXME
 // eslint-disable-next-line
@@ -8,7 +8,6 @@ import { getTileUrl, isCogUrl, isTileServiceUrl } from '../utilities/tileurls.ts
 import CogTiles from '../cogtiles/cogtiles.ts';
 
 import { GeoImageOptions, DefaultGeoImageOptions } from '../geoimage/geoimage.ts';
-import { getColorFromChromaType } from '../geoimage/geoimage.js';
 
 class CogTerrainLayer extends CompositeLayer<any> {
   static layerName = 'CogTerrainLayer';

--- a/geoimage/src/cogterrainlayer/CogTerrainLayer.ts
+++ b/geoimage/src/cogterrainlayer/CogTerrainLayer.ts
@@ -1,12 +1,14 @@
 import { CompositeLayer } from '@deck.gl/core';
 import { TileLayer, TerrainLayer } from '@deck.gl/geo-layers';
+import chroma from "chroma-js";
 
 // FIXME
 // eslint-disable-next-line
 import { getTileUrl, isCogUrl, isTileServiceUrl } from '../utilities/tileurls.ts';
 import CogTiles from '../cogtiles/cogtiles.ts';
 
-import { GeoImageOptions } from '../geoimage/geoimage.ts';
+import { GeoImageOptions, DefaultGeoImageOptions } from '../geoimage/geoimage.ts';
+import { getColorFromChromaType } from '../geoimage/geoimage.js';
 
 class CogTerrainLayer extends CompositeLayer<any> {
   static layerName = 'CogTerrainLayer';
@@ -29,6 +31,12 @@ class CogTerrainLayer extends CompositeLayer<any> {
 
   terrainUrl: string;
 
+  terrainOpacity: number;
+
+  terrainColor: Array<number>;
+
+  terrainSkirtHeight: number;
+
   static displayName: string;
 
   constructor(
@@ -40,15 +48,21 @@ class CogTerrainLayer extends CompositeLayer<any> {
   ) {
     super({});
     this.id = id;
+    const mergedTerrainOptions = { ...DefaultGeoImageOptions, ...terrainOptions };
+    this.terrainOpacity = mergedTerrainOptions.alpha / 100;
+    this.terrainColor = chroma(mergedTerrainOptions.terrainColor.slice(0, 3)).rgb();
+    this.terrainSkirtHeight = mergedTerrainOptions.terrainSkirtHeight;
 
     if (bitmapUrl) {
       if (isTileServiceUrl(bitmapUrl)) {
         this.bitmapUrl = bitmapUrl;
         this.urlType = 'tile';
+        this.terrainColor = [0, 0, 0, 0];
       } else if (isCogUrl(bitmapUrl)) {
         this.bitmapCogTiles = new CogTiles(bitmapOptions!);
         this.bitmapCogTiles.initializeCog(bitmapUrl);
         this.urlType = 'cog';
+        this.terrainColor = [0, 0, 0, 0];
       } else {
         console.warn('URL needs to point to a valid cog file, or needs to be in the {x}{y}{z} format.');
       }
@@ -144,17 +158,19 @@ class CogTerrainLayer extends CompositeLayer<any> {
               },
               elevationData: props.data,
               texture: bitmapTile,
+              opacity: this.terrainOpacity,
               bounds: [props.tile.bbox.west,
                 props.tile.bbox.south,
                 props.tile.bbox.east,
                 props.tile.bbox.north,
               ],
+              color: this.terrainColor,
               operation: 'terrain+draw',
               minZoom: this.minZoom,
               maxZoom: this.maxZoom,
               loadOptions: {
                 terrain: {
-                  skirtHeight: 2000,
+                  skirtHeight: this.terrainSkirtHeight,
                   tesselator: 'martini',
                 },
               },

--- a/geoimage/src/geoimage/README.md
+++ b/geoimage/src/geoimage/README.md
@@ -30,7 +30,7 @@
 
 - `clipHigh : number | null`- generate only data less than this **(default null)**
 - `clippedColor: chroma.Color` - set color for clipped values when using `clipLow` or `clipHigh`, **(default [0, 0, 0, 0])**
-- `colorScale:chroma.Color[]` - array of colors, supports chroma.js color definition such as `'red'`, `[255,0,0]`, `'#FF0000'`, etc. and [Color Brewer pallete names](https://www.datanovia.com/en/wp-content/uploads/dn-tutorials/ggplot2/figures/0101-rcolorbrewer-palette-rcolorbrewer-palettes-colorblind-friendly-1.png) in this format: `chroma.brewer.Greens`
+- `colorScale:chroma.Color[]` - array of colors, supports chroma.js color definition (more below)
 - `colorScaleValueRange: number[]` - set min and max range values or set any array of values to set exact colors to values, **if useAutoRange is false**, **(default [0,255])**
 - `useColorsBasedOnValues: boolean` - assign pixels colors based on defined data values **(default false)**
 - `colorsBasedOnValues : [number, chroma.Color][]` - array of value-color pairs, used **if useColorsBasedOnValues is true**, supports chroma.js color definition such as `'red'`, `[255,0,0]`, `'#FF0000'`, etc.
@@ -41,6 +41,22 @@
 - `useSingleColor : boolean` - display data values only with single color **(default false)**
 - `color : chroma.Color` - set color when **if useSingleColor is true**, **(default [255, 0, 255, 255])**
 - `blurredTexture : boolean` - define blurring behaviour for textures when zoomed in = magnification filter parameter (`gl.TEXTURE_MAG_FILTER`). Default is `true` for blurry textures (corresponds to `GL.LINEAR`), to not blur textures use `false` (corresponds to `GL.NEAREST`)
+
+#### Chroma.Color definition
+Type `chroma.Color` means any color definition that is supported by chroma.js such as `'red'`, `[255,0,0]`, `[255,0,0, 180]`, `'#FF0000'`, 
+etc. and [Color Brewer pallete names](https://www.datanovia.com/en/wp-content/uploads/dn-tutorials/ggplot2/figures/0101-rcolorbrewer-palette-rcolorbrewer-palettes-colorblind-friendly-1.png) 
+in this format: `chroma.brewer.Greens`
+
+#### Additional terrain processing options
+- `terrainMinValue: number` - noData value retreived from input file's metadata is subsitute by this value **(default 0)**
+- `terrainSkirtHeight: number` - defines height of individual tiles edges, so there are no white spaces between individual 3D tiles **(default 100)**
+- `terrainColor: chroma.Color` - color of terrain model **(default [133, 133, 133, 255])**
+
+- Setting **opacity for terrain layers**: when using a terrain layer without defining a bitmap overlay, 
+setting the opacity of the model is straightforward: set `alpha` in terrainOptions (0-100). 
+However, if a bitmap overlay is defined (`bitmapUrl` and `bitmapOptions`), the opacity for 
+the overlay is taken from its definition in `bitmapOptions`, not from `terrainOptions` 
+(which is recommended to be set to 100 unless the opacities are combined). 
 
 ### Return options
 **Method returns Image DataUrl**

--- a/geoimage/src/geoimage/geoimage.ts
+++ b/geoimage/src/geoimage/geoimage.ts
@@ -33,9 +33,12 @@ export type GeoImageOptions = {
     unidentifiedColor?: Array<number> | chroma.Color,
     clippedColor?: Array<number> | chroma.Color,
     clampToTerrain?: ClampToTerrainOptions | boolean, // terrainDrawMode: 'drape',
+    terrainColor?: Array<number> | chroma.Color,
+    terrainSkirtHeight?: number,
+    terrainMinValue?: number
 }
 
-const DefaultGeoImageOptions: GeoImageOptions = {
+export const DefaultGeoImageOptions: GeoImageOptions = {
   type: 'image',
   format: 'uint8',
   useHeatMap: true,
@@ -60,6 +63,9 @@ const DefaultGeoImageOptions: GeoImageOptions = {
   nullColor: [0, 0, 0, 0],
   unidentifiedColor: [0, 0, 0, 0],
   clippedColor: [0, 0, 0, 0],
+  terrainColor: [133, 133, 133, 255],
+  terrainSkirtHeight: 100,
+  terrainMinValue: 0,
 };
 
 export default class GeoImage {
@@ -151,8 +157,7 @@ export default class GeoImage {
     for (let i = 0; i < size; i += 4) {
       //  height image calculation based on:
       //  https://deck.gl/docs/api-reference/geo-layers/terrain-layer
-
-      const elevationValue = channel[pixel] * options.multiplier!;
+      const elevationValue = (options.noDataValue && channel[pixel] === options.noDataValue) ? options.terrainMinValue : channel[pixel] * options.multiplier!;
       const colorValue = Math.floor((elevationValue + 10000) / 0.1);
       imageData.data[i] = Math.floor(colorValue / (256 * 256));
       imageData.data[i + 1] = Math.floor((colorValue / 256) % 256);


### PR DESCRIPTION
I have updated terrain options:
1. added  terrainColor (optional) to set custom color of the terrain model when no bitmap overlay is used
2. opacity for the terrain has been implemented 
3. added option to set custom terrainSkirtHeight (optional) value to change height of the individual terrain tiles edges
4. added option to use noDataValue obtained from input file's metadata, currently the noDataValues (for example -9999) have been used to create the 3D model as it was real height. Now these values can be set to terrainMinValue (default 0)

plus readme updated