### PR TITLE
Earth circumference updated

### DIFF
--- a/geoimage/src/cogtiles/cogtiles.ts
+++ b/geoimage/src/cogtiles/cogtiles.ts
@@ -14,8 +14,8 @@ import GeoImage, { GeoImageOptions } from '../geoimage/geoimage.ts';
 
 export type Bounds = [minX: number, minY: number, maxX: number, maxY: number];
 
-const EARTH_CIRCUMFERENCE = 40075000.0;
-const EARTH_HALF_CIRCUMFERENCE = 20037500.0;
+const EARTH_CIRCUMFERENCE = 2 * Math.PI * 6378137;
+const EARTH_HALF_CIRCUMFERENCE = EARTH_CIRCUMFERENCE / 2;
 
 const CogTilesGeoImageOptionsDefaults = {
   blurredTexture: true,


### PR DESCRIPTION
Fix for incorrectly positioned tiles when the map is zoomed <2.

The issue was that the resolution per pixel per individual zoom level is calculated by formula using `EARTH_CIRCUMFERENCE`. This resolution is then used to access correct COG pyramid level. Since the `EARTH_CIRCUMFERENCE` was not accurate enough the code was taken wrong zoom tiles for zoom levels 0-2.

Wrong position 
<img width="450" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/54218787-b9b9-471e-bae9-968b6df2660a" />

Correct position 
<img width="450" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/dc328291-b506-4df5-9641-31fe4c503a7c" />
