### PR TITLE
ci: add automatic build verification

### DIFF
--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -2,7 +2,6 @@ name: PR Build Check
 
 on:
   pull_request:
-    branches: [ dev, master ]
   workflow_dispatch: # Allows manual triggering if needed
 
 jobs:


### PR DESCRIPTION
Adds a GitHub Action to run yarn build on every PR to prevent build errors.