### PR TITLE
fix: use local semantic-release binary with explicit config flag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,4 +44,4 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: npx semantic-release
+        run: yarn node node_modules/semantic-release/bin/semantic-release.js --config .releaserc.json


### PR DESCRIPTION
## Summary
- Replace `npx semantic-release` with `yarn node node_modules/semantic-release/bin/semantic-release.js --config .releaserc.json` in the release workflow

## Problem
The last release workflow run triggered on `dev` (run [#23340486757](https://github.com/Gisat/deck.gl-geotiff/actions/runs/23340486757)) reported:

> `This test run was triggered on the branch dev, while semantic-release is configured to only publish from master, therefore a new version won't be published.`

This happened despite `.releaserc.json` correctly listing `dev` as a pre-release branch. The root cause is that `npx semantic-release` downloads and executes a fresh copy of semantic-release from the npm registry, which does not correctly resolve the `.releaserc.json` config in this Yarn workspaces environment — falling back to default configuration that only publishes from `master`.

## Solution
Use the locally installed semantic-release binary (`node_modules/semantic-release/bin/semantic-release.js`) via `yarn node`, and pass the config file explicitly with `--config .releaserc.json`. This ensures:
1. The exact installed version is used (no network download, no version drift)
2. The config file is unambiguously resolved regardless of workspace/cwd context

## Changes
- `.github/workflows/release.yml` — replace `npx semantic-release` with `yarn node node_modules/semantic-release/bin/semantic-release.js --config .releaserc.json`