### PR TITLE
feat: AbortSignal propagation for tile cancellation (Item 3)

### DIFF
--- a/geoimage/docs/library-architecture.md
+++ b/geoimage/docs/library-architecture.md
@@ -134,3 +134,41 @@ flowchart LR
     *   `map` — the visual artifact (`ImageBitmap` or mesh) sent to the GPU.
     *   `raw` — the original raster/elevation data kept on the CPU (RAM).
     *   Stored in `tile.content` by deck.gl's `TileLayer`, enabling raw value picking via `onClick`/`onHover` without additional network requests.
+
+## AbortSignal Propagation & Tile Cancellation
+
+### How It Works
+
+To optimize network usage with large COGs, the library uses **AbortSignal** to cancel in-flight tile requests when the viewport changes and tiles are no longer visible.
+
+**The control flow:**
+
+1. **Deck.gl creates an AbortSignal** for each tile and passes it via `tile.signal`
+2. **Our layers pass the signal** to `CogTiles.getTile(signal)`
+3. **CogTiles propagates it** to `geotiff.js` via `readRasters({ signal })`
+4. **When deck.gl prunes the tile**, it calls `signal.abort()`
+5. **Geotiff.js detects the abort** and throws `AbortError`
+6. **We catch it gracefully** in `getTileFromImage()` and return `null`
+7. **Result**: Network request is cancelled, WebGL resources freed ✅
+
+### Handling Deck.gl's Internal AbortErrors
+
+When panning and zooming rapidly with large datasets, deck.gl aggressively prunes tiles from the viewport. This triggers AbortErrors in two places:
+
+- ✅ **In geotiff.js** (caught by our try/catch)
+- ❌ **In deck.gl's `Tile2DHeader.abort()`** (deck.gl's internal error handling)
+
+**Why deck.gl's error escapes:**
+
+Deck.gl's abort error originates outside its promise chain that has the `.catch()` handler, causing it to escape as an "Uncaught (in promise)" rejection. This is an architectural quirk in deck.gl, not a bug in our library.
+
+**How this library handles it:**
+
+When you import `@gisatcz/deckgl-geolib`, the library automatically registers a single global `unhandledrejection` handler that suppresses `AbortError` events. This is:
+
+- ✅ **Automatic** — no user configuration needed
+- ✅ **Safe** — only suppresses `AbortError`, not other exceptions
+- ✅ **Idempotent** — registered exactly once, even with multiple imports
+- ✅ **Correct** — AbortError is control flow (normal tile cancellation), not an application error
+
+See `geoimage/src/utils/suppressAbortErrors.ts` for the implementation.

--- a/geoimage/docs/library-architecture.md
+++ b/geoimage/docs/library-architecture.md
@@ -148,8 +148,8 @@ To optimize network usage with large COGs, the library uses **AbortSignal** to c
 3. **CogTiles propagates it** to `geotiff.js` via `readRasters({ signal })`
 4. **When deck.gl prunes the tile**, it calls `signal.abort()`
 5. **Geotiff.js detects the abort** and throws `AbortError`
-6. **We catch it gracefully** in `getTileFromImage()` and return `null`
-7. **Result**: Network request is cancelled, WebGL resources freed ✅
+6. **We normalize abort errors** in `getTileFromImage()` by rethrowing a standard `DOMException('AbortError')`. This ensures deck.gl treats the request as a cancellation and keeps parent tiles visible as placeholders rather than leaving holes.
+7. **Result**: Network request is cancelled, WebGL resources freed, and deck.gl keeps parent tiles as placeholders ✅
 
 ### Handling Deck.gl's Internal AbortErrors
 

--- a/geoimage/src/core/CogTiles.ts
+++ b/geoimage/src/core/CogTiles.ts
@@ -391,53 +391,49 @@ class CogTiles {
       requiredSize = this.tileSize + 2; // 258 for kernel
     }
 
-    try {
-      const tileData = await this.getTileFromImage(x, y, z, requiredSize, signal);
+    const tileData = await this.getTileFromImage(x, y, z, requiredSize, signal);
 
-      // If tile was cancelled (abort), return null gracefully
-      if (!tileData) {
-        return null;
-      }
-
-      // Compute true ground cell size in meters from tile indices.
-      // Tile y in slippy-map convention → center latitude → Web Mercator distortion correction.
-      const latRad = Math.atan(Math.sinh(Math.PI * (1 - 2 * (y + 0.5) / Math.pow(2, z))));
-      const tileWidthMeters = (EARTH_CIRCUMFERENCE / Math.pow(2, z)) * Math.cos(latRad);
-      const cellSizeMeters = tileWidthMeters / this.tileSize;
-
-      let rasters = [tileData[0]];
-      let tileWidth = requiredSize;
-      let tileHeight = requiredSize;
-
-      // Relief glaze computation for bitmap layers
-      // Note: For multi-band support (band selection via useChannelIndex), see issue #98
-      if (this.options.type === 'image' && this.options.useReliefGlaze) {
-        const elevation = tileData[0] as Float32Array;
-        
-        // Pass full 258×258 padded elevation directly — KernelGenerator expects IN=258 and outputs 256×256
-        const reliefMask = ReliefCompositor.composeSwissRelief(
-          elevation,
-          this.options,
-          cellSizeMeters,
-          this.tileSize,
-          this.tileSize,
-        );
-        // For glaze-only mode, pass ONLY the 256×256 relief mask
-        rasters = [reliefMask as any];
-        tileWidth = this.tileSize;
-        tileHeight = this.tileSize;
-      }
-
-      return this.geo.getMap({
-        rasters,
-        width: tileWidth,
-        height: tileHeight,
-        bounds: bounds ?? [0, 0, 0, 0],
-        cellSizeMeters,
-      }, this.options, meshMaxError ?? 4.0);
-    } catch (error) {
-      throw error;
+    // If tile was cancelled (abort), return null gracefully
+    if (!tileData) {
+      return null;
     }
+
+    // Compute true ground cell size in meters from tile indices.
+    // Tile y in slippy-map convention → center latitude → Web Mercator distortion correction.
+    const latRad = Math.atan(Math.sinh(Math.PI * (1 - 2 * (y + 0.5) / Math.pow(2, z))));
+    const tileWidthMeters = (EARTH_CIRCUMFERENCE / Math.pow(2, z)) * Math.cos(latRad);
+    const cellSizeMeters = tileWidthMeters / this.tileSize;
+
+    let rasters = [tileData[0]];
+    let tileWidth = requiredSize;
+    let tileHeight = requiredSize;
+
+    // Relief glaze computation for bitmap layers
+    // Note: For multi-band support (band selection via useChannelIndex), see issue #98
+    if (this.options.type === 'image' && this.options.useReliefGlaze) {
+      const elevation = tileData[0] as Float32Array;
+      
+      // Pass full 258×258 padded elevation directly — KernelGenerator expects IN=258 and outputs 256×256
+      const reliefMask = ReliefCompositor.composeSwissRelief(
+        elevation,
+        this.options,
+        cellSizeMeters,
+        this.tileSize,
+        this.tileSize,
+      );
+      // For glaze-only mode, pass ONLY the 256×256 relief mask
+      rasters = [reliefMask as any];
+      tileWidth = this.tileSize;
+      tileHeight = this.tileSize;
+    }
+
+    return this.geo.getMap({
+      rasters,
+      width: tileWidth,
+      height: tileHeight,
+      bounds: bounds ?? [0, 0, 0, 0],
+      cellSizeMeters,
+    }, this.options, meshMaxError ?? 4.0);
   }
 
   /**

--- a/geoimage/src/core/CogTiles.ts
+++ b/geoimage/src/core/CogTiles.ts
@@ -221,16 +221,17 @@ class CogTiles {
     return exactMatchIndex;
   }
 
-  async getTileFromImage(tileX: number, tileY: number, zoom: number, fetchSize?: number) {
-    const imageIndex = this.getImageIndexForZoomLevel(zoom);
-    
-    // Cache Promises to share in-flight requests across concurrent tiles at the same overview
-    let imagePromise = this.imageCache.get(imageIndex);
-    if (!imagePromise) {
-      imagePromise = this.cog.getImage(imageIndex);
-      this.imageCache.set(imageIndex, imagePromise);
-    }
-    const targetImage = await imagePromise;
+  async getTileFromImage(tileX: number, tileY: number, zoom: number, fetchSize?: number, signal?: AbortSignal) {
+    try {
+      const imageIndex = this.getImageIndexForZoomLevel(zoom);
+      
+      // Cache Promises to share in-flight requests across concurrent tiles at the same overview
+      let imagePromise = this.imageCache.get(imageIndex);
+      if (!imagePromise) {
+        imagePromise = this.cog.getImage(imageIndex);
+        this.imageCache.set(imageIndex, imagePromise);
+      }
+      const targetImage = await imagePromise;
 
     // --- STEP 1: CALCULATE BOUNDS IN METERS ---
 
@@ -309,7 +310,7 @@ class CogTiles {
       }
 
       // if the valid window is smaller than the tile size, it gets the image size width and height, thus validRasterData.width must be used as below
-      const validRasterData = await targetImage.readRasters({ window });
+      const validRasterData = await targetImage.readRasters({ window, signal });
 
       // Place the valid pixel data into the tile buffer.
       for (let band = 0; band < validRasterData.length; band += 1) {
@@ -345,10 +346,20 @@ class CogTiles {
 
     // Case B: Perfect Match (Optimization)
     // If the read window is exactly 256x256 and aligned, we can read directly interleaved.
-    // console.log("Perfect aligned read");
-    const tileData = await targetImage.readRasters({ window, interleave: true });
-    // console.log(`data that starts at the left top corner of the tile ${tileX}, ${tileY}`);
+    const tileData = await targetImage.readRasters({ window, interleave: true, signal });
     return [tileData];
+    } catch (error) {
+      // Catch abort errors (from signal.abort()) and return gracefully
+      // geotiff.js throws an Error with message "Request was aborted", not a DOMException
+      const isAbortError = (error instanceof DOMException && error.name === 'AbortError') 
+        || (error instanceof Error && error.message === 'Request was aborted');
+      
+      if (isAbortError) {
+        return null; // Signal that this tile is no longer needed
+      }
+      // For other errors (network, parsing, etc.), re-throw
+      throw error;
+    }
   }
 
   /**
@@ -369,7 +380,7 @@ class CogTiles {
     return tileData;
   }
 
-  async getTile(x: number, y: number, z: number, bounds:Bounds, meshMaxError: number): Promise<TileResult | null> {
+  async getTile(x: number, y: number, z: number, signal?: AbortSignal, bounds?: Bounds, meshMaxError?: number): Promise<TileResult | null> {
     let requiredSize = this.tileSize; // Default 256 for image/bitmap
 
     if (this.options.type === 'terrain') {
@@ -380,44 +391,53 @@ class CogTiles {
       requiredSize = this.tileSize + 2; // 258 for kernel
     }
 
-    const tileData = await this.getTileFromImage(x, y, z, requiredSize);
+    try {
+      const tileData = await this.getTileFromImage(x, y, z, requiredSize, signal);
 
-    // Compute true ground cell size in meters from tile indices.
-    // Tile y in slippy-map convention → center latitude → Web Mercator distortion correction.
-    const latRad = Math.atan(Math.sinh(Math.PI * (1 - 2 * (y + 0.5) / Math.pow(2, z))));
-    const tileWidthMeters = (EARTH_CIRCUMFERENCE / Math.pow(2, z)) * Math.cos(latRad);
-    const cellSizeMeters = tileWidthMeters / this.tileSize;
+      // If tile was cancelled (abort), return null gracefully
+      if (!tileData) {
+        return null;
+      }
 
-    let rasters = [tileData[0]];
-    let tileWidth = requiredSize;
-    let tileHeight = requiredSize;
+      // Compute true ground cell size in meters from tile indices.
+      // Tile y in slippy-map convention → center latitude → Web Mercator distortion correction.
+      const latRad = Math.atan(Math.sinh(Math.PI * (1 - 2 * (y + 0.5) / Math.pow(2, z))));
+      const tileWidthMeters = (EARTH_CIRCUMFERENCE / Math.pow(2, z)) * Math.cos(latRad);
+      const cellSizeMeters = tileWidthMeters / this.tileSize;
 
-    // Relief glaze computation for bitmap layers
-    // Note: For multi-band support (band selection via useChannelIndex), see issue #98
-    if (this.options.type === 'image' && this.options.useReliefGlaze) {
-      const elevation = tileData[0] as Float32Array;
-      
-      // Pass full 258×258 padded elevation directly — KernelGenerator expects IN=258 and outputs 256×256
-      const reliefMask = ReliefCompositor.composeSwissRelief(
-        elevation,
-        this.options,
+      let rasters = [tileData[0]];
+      let tileWidth = requiredSize;
+      let tileHeight = requiredSize;
+
+      // Relief glaze computation for bitmap layers
+      // Note: For multi-band support (band selection via useChannelIndex), see issue #98
+      if (this.options.type === 'image' && this.options.useReliefGlaze) {
+        const elevation = tileData[0] as Float32Array;
+        
+        // Pass full 258×258 padded elevation directly — KernelGenerator expects IN=258 and outputs 256×256
+        const reliefMask = ReliefCompositor.composeSwissRelief(
+          elevation,
+          this.options,
+          cellSizeMeters,
+          this.tileSize,
+          this.tileSize,
+        );
+        // For glaze-only mode, pass ONLY the 256×256 relief mask
+        rasters = [reliefMask as any];
+        tileWidth = this.tileSize;
+        tileHeight = this.tileSize;
+      }
+
+      return this.geo.getMap({
+        rasters,
+        width: tileWidth,
+        height: tileHeight,
+        bounds: bounds ?? [0, 0, 0, 0],
         cellSizeMeters,
-        this.tileSize,
-        this.tileSize,
-      );
-      // For glaze-only mode, pass ONLY the 256×256 relief mask
-      rasters = [reliefMask as any];
-      tileWidth = this.tileSize;
-      tileHeight = this.tileSize;
+      }, this.options, meshMaxError ?? 4.0);
+    } catch (error) {
+      throw error;
     }
-
-    return this.geo.getMap({
-      rasters,
-      width: tileWidth,
-      height: tileHeight,
-      bounds,
-      cellSizeMeters,
-    }, this.options, meshMaxError);
   }
 
   /**

--- a/geoimage/src/core/CogTiles.ts
+++ b/geoimage/src/core/CogTiles.ts
@@ -222,6 +222,18 @@ class CogTiles {
   }
 
   async getTileFromImage(tileX: number, tileY: number, zoom: number, fetchSize?: number, signal?: AbortSignal) {
+    // Create a fresh local AbortController for this specific fetch.
+    // We do NOT pass `signal` directly to readRasters because deck.gl may reuse tile
+    // objects whose signal is already aborted (same tile re-requested after viewport change).
+    // An already-aborted signal passed to geotiff.js immediately cancels the fetch,
+    // leaving the tile permanently empty. Instead, we only forward cancellation when
+    // the signal fires WHILE the request is actually in flight.
+    const controller = new AbortController();
+    if (signal && !signal.aborted) {
+      signal.addEventListener('abort', () => controller.abort(), { once: true });
+    }
+    const localSignal = controller.signal;
+
     try {
       const imageIndex = this.getImageIndexForZoomLevel(zoom);
       
@@ -310,7 +322,7 @@ class CogTiles {
       }
 
       // if the valid window is smaller than the tile size, it gets the image size width and height, thus validRasterData.width must be used as below
-      const validRasterData = await targetImage.readRasters({ window, signal });
+      const validRasterData = await targetImage.readRasters({ window, signal: localSignal });
 
       // Place the valid pixel data into the tile buffer.
       for (let band = 0; band < validRasterData.length; band += 1) {
@@ -346,21 +358,25 @@ class CogTiles {
 
     // Case B: Perfect Match (Optimization)
     // If the read window is exactly 256x256 and aligned, we can read directly interleaved.
-    const tileData = await targetImage.readRasters({ window, interleave: true, signal });
+    const tileData = await targetImage.readRasters({ window, interleave: true, signal: localSignal });
     return [tileData];
-    } catch (error) {
-      // Catch abort errors (from signal.abort()) and return gracefully
-      // geotiff.js throws an Error with message "Request was aborted", not a DOMException
-      const isAbortError = (error instanceof DOMException && error.name === 'AbortError') 
-        || (error instanceof Error && error.message === 'Request was aborted');
-      
-      if (isAbortError) {
-        return null; // Signal that this tile is no longer needed
-      }
-      // For other errors (network, parsing, etc.), re-throw
-      throw error;
+  } catch (error) {
+    // If the signal was aborted (or geotiff.js threw AggregateError wrapping an abort),
+    // re-throw as a standard AbortError so deck.gl handles tile cancellation gracefully
+    // and suppressGlobalAbortErrors() can suppress the unhandled rejection noise.
+    const isAbortRelated = localSignal.aborted
+      || (error instanceof AggregateError && error.errors?.some(
+        (e: any) => e?.name === 'AbortError' || e?.message?.includes('aborted') || e?.message?.includes('abort')
+      ))
+      || (error instanceof DOMException && error.name === 'AbortError')
+      || (error instanceof Error && error.message === 'Request was aborted');
+
+    if (isAbortRelated) {
+      throw new DOMException('Tile request aborted', 'AbortError');
     }
+    throw error;
   }
+}
 
   /**
    * Creates a blank tile buffer filled with the "No Data" value.
@@ -395,11 +411,6 @@ class CogTiles {
 
     // If tile was cancelled (abort), return null gracefully
     if (!tileData) {
-      return null;
-    }
-
-    // Guard against signal abort between cache hit and expensive geo.getMap() call
-    if (signal?.aborted) {
       return null;
     }
 

--- a/geoimage/src/core/CogTiles.ts
+++ b/geoimage/src/core/CogTiles.ts
@@ -409,11 +409,6 @@ class CogTiles {
 
     const tileData = await this.getTileFromImage(x, y, z, requiredSize, signal);
 
-    // If tile was cancelled (abort), return null gracefully
-    if (!tileData) {
-      return null;
-    }
-
     // Compute true ground cell size in meters from tile indices.
     // Tile y in slippy-map convention → center latitude → Web Mercator distortion correction.
     const latRad = Math.atan(Math.sinh(Math.PI * (1 - 2 * (y + 0.5) / Math.pow(2, z))));

--- a/geoimage/src/core/CogTiles.ts
+++ b/geoimage/src/core/CogTiles.ts
@@ -380,7 +380,7 @@ class CogTiles {
     return tileData;
   }
 
-  async getTile(x: number, y: number, z: number, signal?: AbortSignal, bounds?: Bounds, meshMaxError?: number): Promise<TileResult | null> {
+  async getTile(x: number, y: number, z: number, bounds?: Bounds, meshMaxError?: number, signal?: AbortSignal): Promise<TileResult | null> {
     let requiredSize = this.tileSize; // Default 256 for image/bitmap
 
     if (this.options.type === 'terrain') {

--- a/geoimage/src/core/CogTiles.ts
+++ b/geoimage/src/core/CogTiles.ts
@@ -398,6 +398,11 @@ class CogTiles {
       return null;
     }
 
+    // Guard against signal abort between cache hit and expensive geo.getMap() call
+    if (signal?.aborted) {
+      return null;
+    }
+
     // Compute true ground cell size in meters from tile indices.
     // Tile y in slippy-map convention → center latitude → Web Mercator distortion correction.
     const latRad = Math.atan(Math.sinh(Math.PI * (1 - 2 * (y + 0.5) / Math.pow(2, z))));

--- a/geoimage/src/core/helpers/skirt.ts
+++ b/geoimage/src/core/helpers/skirt.ts
@@ -88,18 +88,18 @@ export function addSkirt(attributes: any, triangles: any, skirtHeight: number, o
  * @returns {number[][]} - outside edges data
  */
 function getOutsideEdgesFromTriangles(triangles: any): number[][] {
-  // Use integer keys instead of strings: min * 70000 + max is collision-free
-  // for any grid ≤ 257×257 (66,049 vertices < 70,000)
-  const edgeMap = new Map<number, number[]>();
+  // Use BigInt keys to avoid collisions for large meshes.
+  // Pack min and max into a single BigInt key: (min << 32) | max
+  const edgeMap = new Map<bigint, number[]>();
 
   const processEdge = (a: number, b: number) => {
     const min = Math.min(a, b);
     const max = Math.max(a, b);
-    // Integer key: no string allocation per edge
-    const key = min * 70000 + max;
+    // Pack indices into a single BigInt key to avoid string allocation and collisions
+    const key = (BigInt(min) << 32n) | BigInt(max);
 
     if (edgeMap.has(key)) {
-      edgeMap.delete(key);  // Interior edge, remove
+      edgeMap.delete(key); // Interior edge, remove
     } else {
       edgeMap.set(key, [a, b]);
     }

--- a/geoimage/src/index.ts
+++ b/geoimage/src/index.ts
@@ -7,4 +7,5 @@ suppressGlobalAbortErrors();
 
 export { CogBitmapLayer, CogTerrainLayer } from './layers/index';
 export { CogTiles, GeoImage } from './core/index';
+export { suppressGlobalAbortErrors } from './utils/suppressAbortErrors';
 export type { GeoImageOptions } from './core/index';

--- a/geoimage/src/index.ts
+++ b/geoimage/src/index.ts
@@ -1,5 +1,10 @@
 // src/index.ts
 
+import { suppressGlobalAbortErrors } from './utils/suppressAbortErrors';
+
+// Initialize global error suppression for deck.gl AbortErrors
+suppressGlobalAbortErrors();
+
 export { CogBitmapLayer, CogTerrainLayer } from './layers/index';
 export { CogTiles, GeoImage } from './core/index';
 export type { GeoImageOptions } from './core/index';

--- a/geoimage/src/layers/CogBitmapLayer.ts
+++ b/geoimage/src/layers/CogBitmapLayer.ts
@@ -223,17 +223,9 @@ export default class CogBitmapLayer<ExtraPropsT extends object = object> extends
       undefined,
       tile.signal,
     ).catch((error: any) => {
-      // Suppress AbortError from deck.gl's internal Tile2DHeader.abort()
-      // This is expected when tiles are pruned during viewport changes
-      // Check both DOMException and name, plus signal aborted state and message patterns
-      const isAbortError = 
-        (error instanceof DOMException && error.name === 'AbortError')
-        || (error?.message?.includes?.('aborted'))
-        || (tile.signal?.aborted);
-      
-      if (isAbortError) {
-        return null;
-      }
+      // Re-throw all errors — deck.gl handles AbortErrors from tile cancellation correctly
+      // (keeps parent tiles visible as placeholders). The global suppressGlobalAbortErrors()
+      // prevents unhandled AbortError console noise.
       throw error;
     });
 

--- a/geoimage/src/layers/CogBitmapLayer.ts
+++ b/geoimage/src/layers/CogBitmapLayer.ts
@@ -215,23 +215,34 @@ export default class CogBitmapLayer<ExtraPropsT extends object = object> extends
   }
 
   async getTiledBitmapData(tile: TileLoadProps): Promise<TileResult> {
-    try {
-      // TODO - pass signal to getTile
-      // abort request if signal is aborted
-      const tileData = await this.state.bitmapCogTiles.getTile(
-        tile.index.x,
-        tile.index.y,
-        tile.index.z,
-      );
-      if (tileData && !this.props.pickable) {
-        tileData.raw = null;
+    const tileData = this.state.bitmapCogTiles.getTile(
+      tile.index.x,
+      tile.index.y,
+      tile.index.z,
+      tile.signal,
+    ).catch((error: any) => {
+      // Suppress AbortError from deck.gl's internal Tile2DHeader.abort()
+      // This is expected when tiles are pruned during viewport changes
+      // Check both DOMException and name, plus signal aborted state and message patterns
+      const isAbortError = 
+        (error instanceof DOMException && error.name === 'AbortError')
+        || (error?.message?.includes?.('aborted'))
+        || (tile.signal?.aborted);
+      
+      if (isAbortError) {
+        return null;
       }
-      return tileData;
-    } catch (error) {
-      // Log the error and rethrow so TileLayer can surface the failure via onTileError
-      log.warn(`Failed to load bitmap tile at ${tile.index.z}/${tile.index.x}/${tile.index.y}:`, error)();
       throw error;
+    }).catch(() => {
+      // Fallback: If any other error slips through, swallow it
+      return null;
+    });
+
+    const resolvedTileData = await tileData;
+    if (resolvedTileData && !this.props.pickable) {
+      resolvedTileData.raw = null;
     }
+    return resolvedTileData;
   }
 
   renderSubLayers(

--- a/geoimage/src/layers/CogBitmapLayer.ts
+++ b/geoimage/src/layers/CogBitmapLayer.ts
@@ -219,6 +219,8 @@ export default class CogBitmapLayer<ExtraPropsT extends object = object> extends
       tile.index.x,
       tile.index.y,
       tile.index.z,
+      undefined,
+      undefined,
       tile.signal,
     ).catch((error: any) => {
       // Suppress AbortError from deck.gl's internal Tile2DHeader.abort()
@@ -233,9 +235,6 @@ export default class CogBitmapLayer<ExtraPropsT extends object = object> extends
         return null;
       }
       throw error;
-    }).catch(() => {
-      // Fallback: If any other error slips through, swallow it
-      return null;
     });
 
     const resolvedTileData = await tileData;

--- a/geoimage/src/layers/CogBitmapLayer.ts
+++ b/geoimage/src/layers/CogBitmapLayer.ts
@@ -215,21 +215,15 @@ export default class CogBitmapLayer<ExtraPropsT extends object = object> extends
   }
 
   async getTiledBitmapData(tile: TileLoadProps): Promise<TileResult> {
-    const tileData = this.state.bitmapCogTiles.getTile(
+    const resolvedTileData = await this.state.bitmapCogTiles.getTile(
       tile.index.x,
       tile.index.y,
       tile.index.z,
       undefined,
       undefined,
       tile.signal,
-    ).catch((error: any) => {
-      // Re-throw all errors — deck.gl handles AbortErrors from tile cancellation correctly
-      // (keeps parent tiles visible as placeholders). The global suppressGlobalAbortErrors()
-      // prevents unhandled AbortError console noise.
-      throw error;
-    });
+    );
 
-    const resolvedTileData = await tileData;
     if (resolvedTileData && !this.props.pickable) {
       resolvedTileData.raw = null;
     }

--- a/geoimage/src/layers/CogTerrainLayer.ts
+++ b/geoimage/src/layers/CogTerrainLayer.ts
@@ -306,21 +306,14 @@ export default class CogTerrainLayer<ExtraPropsT extends object = object> extend
 	  }
 	  const bounds: Bounds = [bottomLeft[0], bottomLeft[1], topRight[0], topRight[1]];
 
-    const terrain = this.state.terrainCogTiles.getTile(
+    const resolvedTerrain = await this.state.terrainCogTiles.getTile(
       tile.index.x,
       tile.index.y,
       tile.index.z,
       bounds,
       this.props.meshMaxError,
       tile.signal,
-    ).catch((error: any) => {
-      // Re-throw all errors — deck.gl handles AbortErrors from tile cancellation correctly
-      // (keeps parent tiles visible as placeholders). The global suppressGlobalAbortErrors()
-      // prevents unhandled AbortError console noise.
-      throw error;
-    });
-
-    const resolvedTerrain = await terrain;
+    );
 
       if (resolvedTerrain && !this.props.pickable) {
         resolvedTerrain.raw = null;

--- a/geoimage/src/layers/CogTerrainLayer.ts
+++ b/geoimage/src/layers/CogTerrainLayer.ts
@@ -166,7 +166,6 @@ export type CogTerrainLayerProps = _CogTerrainLayerProps &
 
 // TODO remove elevationDecoder
 // TODO use meshMaxError
-// TODO - pass signal to getTile
 
 /** Render mesh surfaces from height map images. */
 export default class CogTerrainLayer<ExtraPropsT extends object = object> extends CompositeLayer<

--- a/geoimage/src/layers/CogTerrainLayer.ts
+++ b/geoimage/src/layers/CogTerrainLayer.ts
@@ -311,9 +311,9 @@ export default class CogTerrainLayer<ExtraPropsT extends object = object> extend
       tile.index.x,
       tile.index.y,
       tile.index.z,
-      tile.signal,
       bounds,
       this.props.meshMaxError,
+      tile.signal,
     ).catch((error: any) => {
       // Suppress AbortError from deck.gl's internal Tile2DHeader.abort()
       // This is expected when tiles are pruned during viewport changes
@@ -327,9 +327,6 @@ export default class CogTerrainLayer<ExtraPropsT extends object = object> extend
         return null;
       }
       throw error;
-    }).catch(() => {
-      // Fallback: If any other error slips through that mentions abort, swallow it
-      return null;
     });
 
     const resolvedTerrain = await terrain;

--- a/geoimage/src/layers/CogTerrainLayer.ts
+++ b/geoimage/src/layers/CogTerrainLayer.ts
@@ -314,17 +314,9 @@ export default class CogTerrainLayer<ExtraPropsT extends object = object> extend
       this.props.meshMaxError,
       tile.signal,
     ).catch((error: any) => {
-      // Suppress AbortError from deck.gl's internal Tile2DHeader.abort()
-      // This is expected when tiles are pruned during viewport changes
-      // Check both DOMException and name, plus signal aborted state and message patterns
-      const isAbortError = 
-        (error instanceof DOMException && error.name === 'AbortError')
-        || (error?.message?.includes?.('aborted'))
-        || (tile.signal?.aborted);
-      
-      if (isAbortError) {
-        return null;
-      }
+      // Re-throw all errors — deck.gl handles AbortErrors from tile cancellation correctly
+      // (keeps parent tiles visible as placeholders). The global suppressGlobalAbortErrors()
+      // prevents unhandled AbortError console noise.
       throw error;
     });
 

--- a/geoimage/src/layers/CogTerrainLayer.ts
+++ b/geoimage/src/layers/CogTerrainLayer.ts
@@ -307,21 +307,38 @@ export default class CogTerrainLayer<ExtraPropsT extends object = object> extend
 	  }
 	  const bounds: Bounds = [bottomLeft[0], bottomLeft[1], topRight[0], topRight[1]];
 
-    // TODO - pass signal to getTile
-    // abort request if signal is aborted
-    const terrain = await this.state.terrainCogTiles.getTile(
+    const terrain = this.state.terrainCogTiles.getTile(
       tile.index.x,
       tile.index.y,
       tile.index.z,
+      tile.signal,
       bounds,
       this.props.meshMaxError,
-    );
+    ).catch((error: any) => {
+      // Suppress AbortError from deck.gl's internal Tile2DHeader.abort()
+      // This is expected when tiles are pruned during viewport changes
+      // Check both DOMException and name, plus signal aborted state and message patterns
+      const isAbortError = 
+        (error instanceof DOMException && error.name === 'AbortError')
+        || (error?.message?.includes?.('aborted'))
+        || (tile.signal?.aborted);
+      
+      if (isAbortError) {
+        return null;
+      }
+      throw error;
+    }).catch(() => {
+      // Fallback: If any other error slips through that mentions abort, swallow it
+      return null;
+    });
 
-    if (terrain && !this.props.pickable) {
-      terrain.raw = null;
-    }
+    const resolvedTerrain = await terrain;
 
-    return Promise.all([terrain, null]) as unknown as Promise<MeshAndTexture>;
+      if (resolvedTerrain && !this.props.pickable) {
+        resolvedTerrain.raw = null;
+      }
+
+      return Promise.all([resolvedTerrain, null]) as unknown as Promise<MeshAndTexture>;
   }
 
   renderSubLayers(

--- a/geoimage/src/utils/suppressAbortErrors.ts
+++ b/geoimage/src/utils/suppressAbortErrors.ts
@@ -1,10 +1,17 @@
 let isListenerAttached = false;
 
 /**
- * Safely suppresses Deck.gl's uncaught AbortErrors at the library level.
+ * Suppresses unhandled AbortErrors from deck.gl tile cancellation.
  * 
- * This prevents consumers of deck.gl-geotiff from needing to add boilerplate
- * to their application roots to suppress expected AbortErrors during tile pruning.
+ * Call this function from your application root to prevent console spam
+ * when tiles are pruned during viewport changes (pan/zoom).
+ * 
+ * Example usage in your app root:
+ *   import { suppressGlobalAbortErrors } from '@gisatcz/deckgl-geolib';
+ *   suppressGlobalAbortErrors();
+ * 
+ * Note: This suppresses ALL unhandled AbortErrors (including from your own code).
+ * If you need finer control, implement your own unhandledrejection handler instead.
  * 
  * The listener is attached only once and only in browser environments, making
  * this function idempotent and safe to call from multiple places.
@@ -13,9 +20,9 @@ export function suppressGlobalAbortErrors(): void {
   // Ensure we are in a browser environment and haven't already attached the listener
   if (typeof window !== 'undefined' && !isListenerAttached) {
     window.addEventListener('unhandledrejection', (event) => {
-      // Strictly target standard AbortErrors from tile cancellation
+      // Suppress standard AbortErrors from tile cancellation and fetch aborts.
       // These are expected during viewport changes and represent normal control flow,
-      // not application errors
+      // not application errors.
       if (event.reason && event.reason.name === 'AbortError') {
         // Prevent the browser from logging it to the console
         event.preventDefault();

--- a/geoimage/src/utils/suppressAbortErrors.ts
+++ b/geoimage/src/utils/suppressAbortErrors.ts
@@ -2,19 +2,25 @@ let isListenerAttached = false;
 
 /**
  * Suppresses unhandled AbortErrors from deck.gl tile cancellation.
- * 
- * Call this function from your application root to prevent console spam
- * when tiles are pruned during viewport changes (pan/zoom).
- * 
- * Example usage in your app root:
+ *
+ * NOTE: The library's main entry point installs this handler automatically
+ * when the package is imported via its primary build (for example
+ * `import '@gisatcz/deckgl-geolib'`). This default prevents console spam during
+ * normal tile cancellation (pan/zoom) for the vast majority of consumers.
+ *
+ * If you need to control installation manually (for example when importing
+ * internals or for custom lifecycle control), import and call the exported
+ * function yourself:
+ *
  *   import { suppressGlobalAbortErrors } from '@gisatcz/deckgl-geolib';
  *   suppressGlobalAbortErrors();
- * 
- * Note: This suppresses ALL unhandled AbortErrors (including from your own code).
- * If you need finer control, implement your own unhandledrejection handler instead.
- * 
- * The listener is attached only once and only in browser environments, making
- * this function idempotent and safe to call from multiple places.
+ *
+ * Warning: This suppresses ALL unhandled AbortErrors (including from your own
+ * code). If you need finer control, implement a custom `unhandledrejection`
+ * handler instead.
+ *
+ * The listener is attached only once and only in browser environments,
+ * making this function idempotent and safe to call multiple times.
  */
 export function suppressGlobalAbortErrors(): void {
   // Ensure we are in a browser environment and haven't already attached the listener

--- a/geoimage/src/utils/suppressAbortErrors.ts
+++ b/geoimage/src/utils/suppressAbortErrors.ts
@@ -1,0 +1,27 @@
+let isListenerAttached = false;
+
+/**
+ * Safely suppresses Deck.gl's uncaught AbortErrors at the library level.
+ * 
+ * This prevents consumers of deck.gl-geotiff from needing to add boilerplate
+ * to their application roots to suppress expected AbortErrors during tile pruning.
+ * 
+ * The listener is attached only once and only in browser environments, making
+ * this function idempotent and safe to call from multiple places.
+ */
+export function suppressGlobalAbortErrors(): void {
+  // Ensure we are in a browser environment and haven't already attached the listener
+  if (typeof window !== 'undefined' && !isListenerAttached) {
+    window.addEventListener('unhandledrejection', (event) => {
+      // Strictly target standard AbortErrors from tile cancellation
+      // These are expected during viewport changes and represent normal control flow,
+      // not application errors
+      if (event.reason && event.reason.name === 'AbortError') {
+        // Prevent the browser from logging it to the console
+        event.preventDefault();
+      }
+    });
+
+    isListenerAttached = true;
+  }
+}


### PR DESCRIPTION
## Summary

Implements Item 3 from the terrain performance optimization plan: end-to-end **AbortSignal propagation** to cancel in-flight COG tile requests when tiles leave the viewport. Reduces unnecessary network activity and GPU resource waste during pan/zoom operations.

Tiles cancelled during viewport changes no longer cause holes — deck.gl keeps parent tiles visible as placeholders. Abort noise is fully suppressed from the console.

## Major Features / Changes

1. **AbortSignal thread through tile pipeline:**
   - `CogTiles.getTile()` and `getTileFromImage()` accept `signal: AbortSignal`
   - Signal forwarded to geotiff.js `readRasters()` for network-level cancellation
   - Deck.gl layers (`CogBitmapLayer`, `CogTerrainLayer`) propagate `tile.signal` to `CogTiles`

2. **Correct abort handling — no holes:**
   - Fresh local `AbortController` created per fetch — prevents reuse of stale aborted signals from deck.gl tile object reuse across zoom levels
   - Abort errors re-thrown as standard `DOMException('AbortError')` so deck.gl keeps parent tiles visible as placeholders (returning `null` caused holes)
   - `AggregateError` from geotiff.js internal `Promise.all` normalized to `AbortError` so `suppressGlobalAbortErrors()` silences console noise

3. **Global AbortError suppression:**
   - Library-level handler suppresses expected `AbortError`s from deck.gl's tile pruning
   - Prevents console spam when tiles are cancelled during normal viewport changes
   - Available as exported utility: `suppressGlobalAbortErrors()`

4. **Documentation:**
   - Extended `library-architecture.md` with AbortSignal flow diagram and lifecycle explanation