### PR TITLE
fix: restore missing useMemo dependencies for zRange feature

### DIFF
--- a/example/src/examples/CogTerrainGlazeExample.tsx
+++ b/example/src/examples/CogTerrainGlazeExample.tsx
@@ -181,7 +181,7 @@ function CogTerrainGlazeExample() {
     }
 
     return layerStack;
-  }, [viewState, cogState]);
+  }, [viewState, cogState, zRange, onZRangeUpdate]);
 
   if (!viewState) {
     return (

--- a/example/src/examples/CogTerrainKernelExample.tsx
+++ b/example/src/examples/CogTerrainKernelExample.tsx
@@ -4,6 +4,7 @@ import { MapView, WebMercatorViewport } from '@deck.gl/core';
 import { TileLayer } from '@deck.gl/geo-layers';
 import { BitmapLayer } from '@deck.gl/layers';
 import { CogTerrainLayer, CogTiles } from '@gisatcz/deckgl-geolib';
+import { useTerrainZRange } from '@gisatcz/deckgl-geolib/react';
 import { COG_TERRAIN_EXAMPLES } from './dataSources';
 import { GeoImageOptions } from '@gisatcz/deckgl-geolib';
 
@@ -209,7 +210,7 @@ function CogTerrainKernelExample() {
         pickable: true,
       }),
     ];
-  }, [viewState, cogState]);
+  }, [viewState, cogState, zRange, onZRangeUpdate]);
 
   const isTransitioning = cogState?.mode !== mode;
 

--- a/geoimage/docs/api-reference.md
+++ b/geoimage/docs/api-reference.md
@@ -296,27 +296,37 @@ When rendering overlay tile layers (OSM, satellite, CartoDB) over 3D terrain wit
 ```typescript
 import { CogTerrainLayer } from '@gisatcz/deckgl-geolib';
 import { useTerrainZRange } from '@gisatcz/deckgl-geolib/react';
+import { TileLayer } from '@deck.gl/geo-layers';
+import { useMemo } from 'react';
 
 function Map3D() {
   const { zRange, onZRangeUpdate } = useTerrainZRange();
 
-  return (
-    <DeckGL layers={[
-      new CogTerrainLayer({
-        id: 'terrain',
-        elevationData: 'https://example.com/dem.tif',
-        terrainOptions: { type: 'terrain' },
-        onZRangeUpdate,
-      }),
-      new TileLayer({
-        id: 'osm-overlay',
-        data: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
-        zRange,  // Pass elevation bounds from terrain
-      }),
-    ]} />
-  );
+  const layers = useMemo(() => [
+    new CogTerrainLayer({
+      id: 'terrain',
+      elevationData: 'https://example.com/dem.tif',
+      terrainOptions: { type: 'terrain' },
+      onZRangeUpdate,
+    }),
+    new TileLayer({
+      id: 'osm-overlay',
+      data: 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
+      zRange,  // Pass elevation bounds from terrain
+    }),
+  ], [zRange, onZRangeUpdate]);  // ⚠️ CRITICAL: Include both hook values!
+
+  return <DeckGL layers={layers} />;
 }
 ```
+
+> ⚠️ **CRITICAL useMemo Dependencies:** When using `useMemo` to create your layers array, **you MUST include `zRange` and `onZRangeUpdate` in the dependency array**. Without these dependencies:
+> - When the terrain layer updates the elevation bounds (as tiles load), the `onZRangeUpdate` callback fires
+> - React won't re-create the layers array because the dependencies haven't changed
+> - The TileLayer keeps the stale `zRange: null` value
+> - **Result:** Overlay tiles clip when the viewport is tilted, defeating the fix
+>
+> **Summary:** `[zRange, onZRangeUpdate]` is not optional—it's required for the feature to work.
 
 **Manual Alternative (without hook):**
 ```typescript

--- a/geoimage/docs/showcase-layers.md
+++ b/geoimage/docs/showcase-layers.md
@@ -525,13 +525,15 @@ function TerrainWithOSM() {
       terrainOptions: { type: 'terrain' },
       onZRangeUpdate: onZRangeUpdate,  // ← 3. Sync elevation bounds to hook
     }),
-  ], [zRange]);
+  ], [zRange, onZRangeUpdate]);  // ⚠️ CRITICAL: Include both hook values in dependencies!
 
   return <DeckGL layers={layers} /* ... */ />;
 }
 ```
 
 **That's it!** 3 lines: import hook, call hook, wire to layers.
+
+> ⚠️ **CRITICAL:** If you wrap the layers array in `useMemo`, **you MUST include `zRange` and `onZRangeUpdate` in the dependency array**, as shown above. Without these dependencies, when the terrain updates the elevation bounds, React won't re-create the layers array with the new `zRange` value. This causes the overlay tiles to remain at the stale `zRange: null`, resulting in tile clipping when the viewport is tilted.
 
 #### Alternative: Manual State Management
 


### PR DESCRIPTION
## Summary

Fixes the non-functional tile clipping fix from PR #150 by restoring critical React dependencies.

## The Problem

The zRange feature for overlay tile culling wasn't working because:
1. Missing `zRange` and `onZRangeUpdate` in `useMemo` dependency arrays (examples)
2. Missing `useTerrainZRange` import in one example file
3. Documentation didn't warn about the critical dependency requirement

When these dependencies are missing, React doesn't re-create the layers array when elevation bounds update, so the TileLayer stays at `zRange: null` and tiles clip when viewport is tilted.

## Changes

### Code Fixes
- **CogTerrainGlazeExample.tsx**: Add `zRange, onZRangeUpdate` to useMemo deps (line 184)
- **CogTerrainKernelExample.tsx**: 
  - Add missing `useTerrainZRange` import from `@gisatcz/deckgl-geolib/react`
  - Add `zRange, onZRangeUpdate` to useMemo deps (line 212)

### Documentation Updates
- **api-reference.md**: Updated useTerrainZRange example to show proper useMemo usage with correct dependency array + added detailed warning blockquote
- **showcase-layers.md**: Fixed code example dependency array + added critical warning about the requirement

## Testing

✅ TypeScript type-checking passes  
✅ Library builds successfully  
✅ Examples compile without errors

## Related

Fixes PR #150 regression where overlay tiles would clip when viewport is tilted in 3D.