### PR TITLE
feat: move terrain tessellation to Web Worker pool

### DIFF
--- a/.plan/2026-06-06-lod-placeholder-layer.md
+++ b/.plan/2026-06-06-lod-placeholder-layer.md
@@ -1,0 +1,149 @@
+# LOD Placeholder Layer — Progressive Terrain Loading
+
+**Date:** 2026-06-06  
+**Status:** Planning
+
+---
+
+## Problem
+
+COG tiles are served from Linode Object Storage over **HTTP/1.1**. Browsers enforce a strict limit of **6 concurrent connections per domain**.
+
+When the map loads at a high zoom level, deck.gl requests 16+ terrain tiles simultaneously. Only 6 download at a time; the rest queue. On slow connections this leaves the map **blank for several seconds**.
+
+The Web Worker pool (implemented in `2026-06-04-web-worker-terrain-tessellation.md`) eliminated the CPU bottleneck. Network latency is now the primary bottleneck.
+
+---
+
+## Rejected Approaches
+
+| Approach | Why Rejected |
+|---|---|
+| Async generator (`yield` low-res then high-res in `getTileData`) | `TileLayer.getTileData` in deck.gl v9.3 only accepts `Promise<DataT>`, not `AsyncIterable`. Not supported. |
+| Parent tile crop + upscale | Martini requires exactly `(tileSize+1)²` input. Cropped quadrant (129×129 or 65×65) must be bilinearly upscaled — significant complexity with elevation-specific math. |
+
+---
+
+## Chosen Solution: Placeholder Layer
+
+Add a **second `CogTerrainLayer` instance** locked to the COG's minimum zoom level. It fetches 1–4 tiles to cover the entire DEM and tessellates them instantly with a very high `meshMaxError`. The normal detail layer renders on top as tiles load.
+
+### How overlay clamping still works
+
+Both `operation: 'terrain'` and `operation: 'terrain+draw'` patterns write to the **GPU depth buffer**. `TerrainExtension` reads the depth buffer — not a specific layer reference — so satellite/OSM imagery drapes correctly onto the placeholder in areas where detail tiles have not yet loaded.
+
+---
+
+## Visual Behaviour
+
+| State | What the user sees |
+|---|---|
+| Initial load | Low-res terrain mesh covering full DEM + satellite/OSM draped on it |
+| Detail tiles loading | Detail tiles pop in tile by tile, satellite re-drapes on detail depth |
+| Fully loaded | Full-detail terrain, placeholder hidden underneath |
+
+---
+
+## Implementation Checklist
+
+### 1. Add `zoomOverride` prop to `CogTerrainLayer`
+
+**File:** `geoimage/src/layers/CogTerrainLayer.ts`
+
+- 1.1. Add `zoomOverride?: number` to `_CogTerrainLayerProps` type
+- 1.2. Add to `defaultProps` as `{ type: 'number', value: undefined, optional: true }`
+- 1.3. In `renderLayers()`, replace hardcoded state values:
+  ```ts
+  minZoom: this.props.zoomOverride ?? this.state.minZoom,
+  maxZoom: this.props.zoomOverride ?? this.state.maxZoom,
+  ```
+
+### 2. Forward `getPolygonOffset` to the sublayer
+
+**File:** `geoimage/src/layers/CogTerrainLayer.ts`
+
+- 2.1. Do **NOT** add `getPolygonOffset` to `_CogTerrainLayerProps` — it is already defined in deck.gl's base `LayerProps` as:
+  ```ts
+  getPolygonOffset?: (params: { layerIndex: number }) => [number, number] | null;
+  ```
+  Adding it again would create a type conflict.
+- 2.2. No `defaultProps` entry needed — the prop is inherited.
+- 2.3. In `renderSubLayers()`, explicitly forward it to `SimpleMeshLayer` (the `CompositeLayer`'s own polygon offset does **not** cascade to sublayers automatically):
+  ```ts
+  getPolygonOffset: this.props.getPolygonOffset ?? ((params: { layerIndex: number }) => [0, -params.layerIndex * 100]),
+  ```
+  > The fallback `[0, -layerIndex * 100]` matches deck.gl's own default so non-placeholder layers are unaffected.
+
+### 3. Update type exports
+
+**File:** `geoimage/src/core/types.ts` (or `CogTerrainLayer.ts` type export)
+
+- 3.1. Ensure `zoomOverride` and `getPolygonOffset` appear in the exported `CogTerrainLayerProps` type
+
+### 4. Update example app
+
+**File:** `example/src/examples/CogTerrainLayerExample.tsx` (and `CogTerrainGlazeExample.tsx`)
+
+- 4.1. Add a placeholder `CogTerrainLayer` below the detail layer using the shared `cogTiles` instance:
+  ```tsx
+  // Placeholder layer — locked to lowest zoom, instant tessellation
+  new CogTerrainLayer({
+    id: 'cog-terrain-placeholder',
+    elevationData: mainCog.url,
+    cogTiles: initializedCog,           // shared instance — no extra metadata fetch
+    isTiled: true,
+    tileSize: 256,
+    meshMaxError: 80,                   // coarse mesh, fast tessellation
+    zoomOverride: initializedCog.getZoomRange()[0],  // force minZoom = maxZoom = lowest COG zoom
+    operation: 'terrain+draw',          // or 'terrain' — match detail layer
+    disableTexture: true,               // no texture fetch — saves 1 HTTP connection
+    color: [180, 180, 180],             // neutral gray while detail loads
+    getPolygonOffset: () => [0, 100],   // function signature required — push back in depth
+    terrainOptions,
+    pickable: false,
+  }),
+  // Detail layer — normal
+  new CogTerrainLayer({
+    id: 'cog-terrain-layer',
+    ...
+  }),
+  ```
+- 4.2. Ensure placeholder layer is **below** detail layer in the array (renders first → depth overwritten by detail)
+- 4.3. Confirm satellite/OSM TileLayer with `TerrainExtension` is **above** both terrain layers
+
+---
+
+## Key Design Decisions
+
+### Shared `CogTiles` instance
+Both placeholder and detail layers use `cogTiles: initializedCog`. This avoids a second COG metadata fetch and a second worker pool allocation. The `initializeCog()` guard prevents double-initialization.
+
+### `zoomOverride = getZoomRange()[0]`
+`getZoomRange()[0]` returns `minZoom` (the lowest overview level). At that zoom, the entire DEM fits in 1–4 tiles. With `meshMaxError: 80`, Martini tessellates in <5ms per tile.
+
+### `disableTexture: true` on placeholder
+Prevents a texture fetch, leaving one more HTTP connection slot for detail tiles.
+
+### `getPolygonOffset: () => [0, 100]`
+Pushes the placeholder mesh back in depth so detail tiles always render cleanly on top without Z-fighting. The prop type is a **function** `(params) => [number, number]` — passing a plain array would be a type error. Positive units = further from camera = loses depth test to the detail layer whose default is `[0, -layerIndex * 100]` (negative = wins).
+
+### Z-fighting fallback for oblique angles
+At high pitch (>60°), WebGL depth buffer precision degrades and polygon offset alone can fail. If flickering appears on the horizon, apply a **`modelMatrix` translation** on the `SimpleMeshLayer` sublayer to shift the entire placeholder mesh down by a small amount (e.g., −2 m in Cartesian Z). This requires no changes to the tessellation pipeline and is safer than attempting to post-process Martini vertex buffers after the Web Worker returns them.
+
+---
+
+## Files to Change
+
+| File | Change |
+|---|---|
+| `geoimage/src/layers/CogTerrainLayer.ts` | Add `zoomOverride`, `getPolygonOffset` props; wire into `renderLayers` and `renderSubLayers` |
+| `example/src/examples/CogTerrainLayerExample.tsx` | Add placeholder layer |
+| `example/src/examples/CogTerrainGlazeExample.tsx` | Add placeholder layer |
+
+---
+
+## Out of Scope
+
+- HTTP/2 migration (investigate separately with infra team — would eliminate the root cause entirely)
+- Full LOD crop+upscale pipeline (re-evaluate if placeholder approach is insufficient)
+- `CogBitmapLayer` placeholder (bitmap tiles queue differently; less severe bottleneck)

--- a/example/vite.config.ts
+++ b/example/vite.config.ts
@@ -3,8 +3,28 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import path from 'path';
 
+// Custom plugin to handle web-worker: imports (convert to Vite ?worker syntax)
+const webWorkerVitePlugin = {
+  name: 'web-worker-handler',
+  resolveId(id, importer) {
+    if (id.startsWith('web-worker:')) {
+      // Extract the relative path from web-worker: prefix
+      const relativePath = id.replace(/^web-worker:/, '');
+      
+      // Resolve relative to the importing file
+      if (importer) {
+        const importerDir = path.dirname(importer);
+        const resolvedPath = path.resolve(importerDir, relativePath);
+        return { id: resolvedPath + '?worker', external: false };
+      }
+      
+      return relativePath + '?worker';
+    }
+  },
+};
+
 export default defineConfig({
-  plugins: [react()],
+  plugins: [webWorkerVitePlugin, react()],
   publicDir: './public',
   resolve: {
     alias: [

--- a/geoimage/rollup.config.mjs
+++ b/geoimage/rollup.config.mjs
@@ -4,6 +4,7 @@ import typescript from '@rollup/plugin-typescript';
 import terser from '@rollup/plugin-terser';
 import json from '@rollup/plugin-json';
 import filesize from 'rollup-plugin-filesize';
+import webWorkerLoader from 'rollup-plugin-web-worker-loader';
 import path from 'path';
 
 const packageJson = {
@@ -32,6 +33,15 @@ const external = [
 // Reusable plugin stack
 const getPlugins = (isEsm) => [
   json(),
+  // ⚠️ CRITICAL: webWorkerLoader must come BEFORE resolve() and typescript()
+  // so it can intercept worker imports before resolution
+  webWorkerLoader({
+    targetPlatform: 'browser',
+    inline: true,           // ← Inline worker as base64 Blob URL
+    loadPath: '',           // ← No external .js files
+    preserveSource: false,  // ← Remove source after bundling
+    extensions: ['.ts'],    // ← Support TypeScript workers
+  }),
   resolve({
     preferBuiltins: true,
     browser: true,

--- a/geoimage/src/core/CogTiles.ts
+++ b/geoimage/src/core/CogTiles.ts
@@ -4,6 +4,7 @@ import { fromUrl, GeoTIFF, type BlockedSourceOptions } from 'geotiff';
 import GeoImage from './GeoImage';
 import { GeoImageOptions, TileResult, TypedArray } from './types';
 import { ReliefCompositor } from './lib/ReliefCompositor';
+import { getGlobalTerrainWorkerPool } from '../workers/TerrainWorkerPool';
 
 export type Bounds = [minX: number, minY: number, maxX: number, maxY: number];
 
@@ -56,6 +57,7 @@ class CogTiles {
   // future cache hits just await the already-resolved promise directly.
   private cache = new TileCacheManager();
   private tileReader?: TileReader;
+  private workerPool?: any; // TerrainWorkerPool (for terrain tiles)
 
   // Store initialization promise to prevent concurrent duplicate initializations
   private initializePromise?: Promise<void>;
@@ -65,6 +67,12 @@ class CogTiles {
 
   constructor(options: GeoImageOptions) {
     this.options = { ...CogTilesGeoImageOptionsDefaults, ...options };
+
+    // Get reference to global worker pool for terrain tiles
+    // Do NOT create a new pool per instance — reuse the singleton
+    if (options.type === 'terrain') {
+      this.workerPool = getGlobalTerrainWorkerPool();
+    }
   }
 
   async initializeCog(url: string) {
@@ -658,7 +666,7 @@ class CogTiles {
         height: requiredSize,
         bounds: bounds ?? [0, 0, 0, 0],
         cellSizeMeters,
-      }, generatorOptions, resolvedMeshMaxError);
+      }, generatorOptions, resolvedMeshMaxError, this.workerPool);
     })();
 
     const entry = {
@@ -722,7 +730,7 @@ class CogTiles {
       height: this.tileSize,
       bounds: bounds ?? [0, 0, 0, 0],
       cellSizeMeters,
-    }, this.options, meshMaxError ?? 4.0);
+    }, this.options, meshMaxError ?? 4.0, this.workerPool);
   }
 
   private async getBitmapTile(x: number, y: number, z: number, bounds: Bounds | undefined, cellSizeMeters: number, meshMaxError?: number, signal?: AbortSignal): Promise<TileResult | null> {
@@ -746,7 +754,7 @@ class CogTiles {
       height: this.tileSize,
       bounds: bounds ?? [0, 0, 0, 0],
       cellSizeMeters,
-    }, this.options, meshMaxError ?? 4.0);
+    }, this.options, meshMaxError ?? 4.0, this.workerPool);
   }
 
   async getTileAllBands(x: number, y: number, z: number, meshMaxError?: number, signal?: AbortSignal, bounds?: Bounds): Promise<TileResult[]> {
@@ -862,7 +870,7 @@ class CogTiles {
           height: FETCH_SIZE,
           bounds: bounds ?? [0, 0, 0, 0],
           cellSizeMeters,
-        }, generatorOptions, resolvedMeshMaxError);
+        }, generatorOptions, resolvedMeshMaxError, this.workerPool);
 
         if (tileResult) results.push(tileResult);
       }

--- a/geoimage/src/core/CogTiles.ts
+++ b/geoimage/src/core/CogTiles.ts
@@ -666,7 +666,7 @@ class CogTiles {
         height: requiredSize,
         bounds: bounds ?? [0, 0, 0, 0],
         cellSizeMeters,
-      }, generatorOptions, resolvedMeshMaxError, this.workerPool);
+      }, generatorOptions, resolvedMeshMaxError, this.workerPool, controller.signal);
     })();
 
     const entry = {
@@ -730,7 +730,7 @@ class CogTiles {
       height: this.tileSize,
       bounds: bounds ?? [0, 0, 0, 0],
       cellSizeMeters,
-    }, this.options, meshMaxError ?? 4.0, this.workerPool);
+    }, this.options, meshMaxError ?? 4.0, this.workerPool, signal);
   }
 
   private async getBitmapTile(x: number, y: number, z: number, bounds: Bounds | undefined, cellSizeMeters: number, meshMaxError?: number, signal?: AbortSignal): Promise<TileResult | null> {
@@ -870,7 +870,7 @@ class CogTiles {
           height: FETCH_SIZE,
           bounds: bounds ?? [0, 0, 0, 0],
           cellSizeMeters,
-        }, generatorOptions, resolvedMeshMaxError, this.workerPool);
+        }, generatorOptions, resolvedMeshMaxError, this.workerPool, signal);
 
         if (tileResult) results.push(tileResult);
       }

--- a/geoimage/src/core/GeoImage.ts
+++ b/geoimage/src/core/GeoImage.ts
@@ -31,6 +31,7 @@ export default class GeoImage {
     options: GeoImageOptions,
     meshMaxError: number,
     workerPool?: any, // TerrainWorkerPool (optional)
+    signal?: AbortSignal,
   ): Promise<TileResult | null> {
     const mergedOptions = GeoImage.resolveVisualizationMode(
       { ...DefaultGeoImageOptions, ...options },
@@ -41,7 +42,7 @@ export default class GeoImage {
       case 'image':
         return this.getBitmap(input, mergedOptions);
       case 'terrain':
-        return this.getHeightmap(input, mergedOptions, meshMaxError, workerPool);
+        return this.getHeightmap(input, mergedOptions, meshMaxError, workerPool, signal);
       default:
         return null;
     }
@@ -117,32 +118,33 @@ export default class GeoImage {
     options: GeoImageOptions,
     meshMaxError: number,
     workerPool?: any, // TerrainWorkerPool (optional)
+   signal?: AbortSignal,
   ): Promise<TileResult> {
-    let rasters = [];
-    let width: number;
-    let height: number;
-    let bounds: Bounds;
-    let cellSizeMeters: number | undefined;
+   let rasters = [];
+   let width: number;
+   let height: number;
+   let bounds: Bounds;
+   let cellSizeMeters: number | undefined;
 
-    if (typeof (input) === 'string') {
-      // TODO not tested
-      // input is type of object
-      await this.setUrl(input);
+   if (typeof (input) === 'string') {
+     // TODO not tested
+     // input is type of object
+     await this.setUrl(input);
 
-      rasters = (await this.data!.readRasters()) as TypedArray[];
-      width = this.data!.getWidth();
-      height = this.data!.getHeight();
-      bounds = this.data!.getBoundingBox() as Bounds;
-    } else {
-      rasters = input.rasters;
-      width = input.width;
-      height = input.height;
-      bounds = input.bounds;
-      cellSizeMeters = input.cellSizeMeters;
-    }
+     rasters = (await this.data!.readRasters()) as TypedArray[];
+     width = this.data!.getWidth();
+     height = this.data!.getHeight();
+     bounds = this.data!.getBoundingBox() as Bounds;
+   } else {
+     rasters = input.rasters;
+     width = input.width;
+     height = input.height;
+     bounds = input.bounds;
+     cellSizeMeters = input.cellSizeMeters;
+   }
 
-    // Delegate to TerrainGenerator with worker pool
-    return await TerrainGenerator.generate({ width, height, rasters, bounds, cellSizeMeters }, options, meshMaxError, workerPool);
+   // Delegate to TerrainGenerator with worker pool and cancellation signal
+   return await TerrainGenerator.generate({ width, height, rasters, bounds, cellSizeMeters }, options, meshMaxError, workerPool, signal);
   }
 
   async getBitmap(

--- a/geoimage/src/core/GeoImage.ts
+++ b/geoimage/src/core/GeoImage.ts
@@ -30,6 +30,7 @@ export default class GeoImage {
         },
     options: GeoImageOptions,
     meshMaxError: number,
+    workerPool?: any, // TerrainWorkerPool (optional)
   ): Promise<TileResult | null> {
     const mergedOptions = GeoImage.resolveVisualizationMode(
       { ...DefaultGeoImageOptions, ...options },
@@ -40,7 +41,7 @@ export default class GeoImage {
       case 'image':
         return this.getBitmap(input, mergedOptions);
       case 'terrain':
-        return this.getHeightmap(input, mergedOptions, meshMaxError);
+        return this.getHeightmap(input, mergedOptions, meshMaxError, workerPool);
       default:
         return null;
     }
@@ -115,6 +116,7 @@ export default class GeoImage {
         },
     options: GeoImageOptions,
     meshMaxError: number,
+    workerPool?: any, // TerrainWorkerPool (optional)
   ): Promise<TileResult> {
     let rasters = [];
     let width: number;
@@ -139,8 +141,8 @@ export default class GeoImage {
       cellSizeMeters = input.cellSizeMeters;
     }
 
-    // Delegate to TerrainGenerator
-    return await TerrainGenerator.generate({ width, height, rasters, bounds, cellSizeMeters }, options, meshMaxError);
+    // Delegate to TerrainGenerator with worker pool
+    return await TerrainGenerator.generate({ width, height, rasters, bounds, cellSizeMeters }, options, meshMaxError, workerPool);
   }
 
   async getBitmap(

--- a/geoimage/src/core/lib/TerrainGenerator.ts
+++ b/geoimage/src/core/lib/TerrainGenerator.ts
@@ -13,7 +13,8 @@ export class TerrainGenerator {
     input: { width: number; height: number; rasters: TypedArray[] ; bounds: Bounds; cellSizeMeters?: number },
     options: GeoImageOptions,
     meshMaxError: number,
-    workerPool?: any // TerrainWorkerPool (optional for flexibility)
+    workerPool?: any, // TerrainWorkerPool (optional for flexibility)
+    signal?: AbortSignal,
   ): Promise<TileResult> {
     const { width, height } = input;
     const isKernel = width === 258;
@@ -44,6 +45,7 @@ export class TerrainGenerator {
         tesselator: options.tesselator || 'martini',
         width: meshWidth,
         height: meshHeight,
+        signal, // ← Thread cancellation signal to worker
       });
 
       mesh = { vertices: result.vertices, triangles: result.triangles };

--- a/geoimage/src/core/lib/TerrainGenerator.ts
+++ b/geoimage/src/core/lib/TerrainGenerator.ts
@@ -7,12 +7,14 @@ import { BitmapGenerator } from './BitmapGenerator';
 import { KernelGenerator } from './KernelGenerator';
 import { ReliefCompositor } from './ReliefCompositor';
 import { isF32NoData } from './numberUtils';
+import type { ComputeMeshOptions } from '../../workers/TerrainWorkerPool';
 
 export class TerrainGenerator {
   static async generate(
     input: { width: number; height: number; rasters: TypedArray[] ; bounds: Bounds; cellSizeMeters?: number },
     options: GeoImageOptions,
-    meshMaxError: number
+    meshMaxError: number,
+    workerPool?: any // TerrainWorkerPool (optional for flexibility)
   ): Promise<TileResult> {
     const { width, height } = input;
     const isKernel = width === 258;
@@ -30,24 +32,42 @@ export class TerrainGenerator {
     // 2. Tesselate (Generate Mesh)
     const { terrainSkirtHeight, verticalExaggeration = 1.0 } = options;
 
-    let mesh;
-    switch (options.tesselator) {
-      case 'martini':
-        mesh = this.getMartiniTileMesh(meshMaxError, meshWidth, meshTerrain);
-        break;
-      case 'delatin':
-        mesh = this.getDelatinTileMesh(meshMaxError, meshWidth, meshHeight, meshTerrain);
-        break;
+    let mesh: { vertices: Uint16Array; triangles: Uint32Array };
+    let meshTerrainForAttributes: Float32Array; // ← Will hold terrain for getMeshAttributes()
 
-      default:
-        // Intentional: default to Martini for any unspecified or unrecognized tesselator.
-        mesh = this.getMartiniTileMesh(meshMaxError, meshWidth, meshTerrain);
-        break;
+    if (workerPool) {
+      // ✅ NEW: Offload to Web Worker with ZERO-COPY ROUNDTRIP
+      // Transfer meshTerrain to worker; worker transfers it back alongside mesh
+      // This avoids meshTerrain.slice() allocation on main thread
+      const result = await workerPool.computeMesh({
+        terrain: meshTerrain, // ← Transferred to worker (detached here)
+        meshMaxError,
+        tesselator: options.tesselator || 'martini',
+        width: meshWidth,
+        height: meshHeight,
+      });
+
+      mesh = { vertices: result.vertices, triangles: result.triangles };
+      meshTerrainForAttributes = result.terrain; // ← Transferred back from worker
+    } else {
+      // ❌ FALLBACK: Synchronous (old behavior, kept for safety)
+      switch (options.tesselator) {
+        case 'martini':
+          mesh = this.getMartiniTileMesh(meshMaxError, meshWidth, meshTerrain);
+          break;
+        case 'delatin':
+          mesh = this.getDelatinTileMesh(meshMaxError, meshWidth, meshHeight, meshTerrain);
+          break;
+        default:
+          mesh = this.getMartiniTileMesh(meshMaxError, meshWidth, meshTerrain);
+          break;
+      }
+      meshTerrainForAttributes = meshTerrain; // ← Use original
     }
 
     const { vertices } = mesh;
     let { triangles } = mesh;
-    let attributes = this.getMeshAttributes(vertices, meshTerrain, meshWidth, meshHeight, input.bounds, verticalExaggeration);
+    let attributes = this.getMeshAttributes(vertices, meshTerrainForAttributes, meshWidth, meshHeight, input.bounds, verticalExaggeration);
     // Compute bounding box before adding skirt so that z values are not skewed
     const boundingBox = getMeshBoundingBox(attributes);
 

--- a/geoimage/src/core/lib/TerrainGenerator.ts
+++ b/geoimage/src/core/lib/TerrainGenerator.ts
@@ -7,7 +7,6 @@ import { BitmapGenerator } from './BitmapGenerator';
 import { KernelGenerator } from './KernelGenerator';
 import { ReliefCompositor } from './ReliefCompositor';
 import { isF32NoData } from './numberUtils';
-import type { ComputeMeshOptions } from '../../workers/TerrainWorkerPool';
 
 export class TerrainGenerator {
   static async generate(

--- a/geoimage/src/core/lib/TerrainGenerator.ts
+++ b/geoimage/src/core/lib/TerrainGenerator.ts
@@ -48,6 +48,7 @@ export class TerrainGenerator {
 
       mesh = { vertices: result.vertices, triangles: result.triangles };
       meshTerrainForAttributes = result.terrain; // ← Transferred back from worker
+      meshTerrain = result.terrain; // ← Reassign for downstream use (tileResult.raw, etc.)
     } else {
       // ❌ FALLBACK: Synchronous (old behavior, kept for safety)
       switch (options.tesselator) {

--- a/geoimage/src/core/lib/TerrainGenerator.ts
+++ b/geoimage/src/core/lib/TerrainGenerator.ts
@@ -25,7 +25,7 @@ export class TerrainGenerator {
     // For kernel tiles, the mesh uses the inner 257×257 sub-grid (rows 1–257, cols 1–257)
     // so that row 0 / col 0 (kernel padding) is dropped while the bottom/right stitching
     // overlap is preserved.
-    const meshTerrain = isKernel ? this.extractMeshRaster(terrain) : terrain;
+    let meshTerrain = isKernel ? this.extractMeshRaster(terrain) : terrain;
     const meshWidth = isKernel ? 257 : width;
     const meshHeight = isKernel ? 257 : height;
 

--- a/geoimage/src/index.ts
+++ b/geoimage/src/index.ts
@@ -9,5 +9,6 @@ export { CogBitmapLayer, CogTerrainLayer } from './layers/index';
 export { CogTiles, GeoImage } from './core/index';
 export { suppressGlobalAbortErrors } from './utils/suppressAbortErrors';
 export { extractTerrainCoordinate, sampleTerrainTileCoordinates } from './utils/terrainPickingUtils';
+export { terminateGlobalTerrainWorkerPool } from './workers/TerrainWorkerPool';
 export type { GeoImageOptions } from './core/index';
 export type { TerrainCoordinate } from './utils/terrainPickingUtils';

--- a/geoimage/src/layers/CogTerrainLayer.ts
+++ b/geoimage/src/layers/CogTerrainLayer.ts
@@ -172,6 +172,7 @@ export type CogTerrainLayerProps = _CogTerrainLayerProps &
    * Callback fired when the terrain zRange is updated.
    * Used to sync overlay TileLayer zRange for proper 3D frustum culling.
    */
+  // eslint-disable-next-line no-unused-vars
   onZRangeUpdate?: (zRange: ZRange | null) => void;
 
 	/**

--- a/geoimage/src/workers/TerrainWorkerPool.ts
+++ b/geoimage/src/workers/TerrainWorkerPool.ts
@@ -154,9 +154,40 @@ class TerrainWorkerPool {
     }
   }
 
-  // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
   private handleWorkerError(e: ErrorEvent) {
-    // Global worker errors are rare; errors are already handled in handleWorkerMessage
+    // Find which worker failed (e.target is the Worker instance)
+    const failedWorker = e.target as Worker;
+    
+    // Find all pending tasks assigned to this worker
+    const failedTaskIds: string[] = [];
+    this.pendingTasks.forEach((task, taskId) => {
+      if (task.worker === failedWorker) {
+        failedTaskIds.push(taskId);
+      }
+    });
+    
+    // Reject all tasks for the failed worker
+    for (const taskId of failedTaskIds) {
+      const task = this.pendingTasks.get(taskId);
+      if (task) {
+        this.pendingTasks.delete(taskId);
+        task.reject(new Error(`Worker crashed: ${e.message || 'Unknown error'}`));
+      }
+    }
+    
+    // Respawn the failed worker to maintain pool capacity
+    const workerIndex = this.workers.indexOf(failedWorker);
+    if (workerIndex !== -1) {
+      try {
+        const newWorker = new TerrainWorker();
+        newWorker.onmessage = this.handleWorkerMessage.bind(this);
+        newWorker.onerror = this.handleWorkerError.bind(this);
+        this.workers[workerIndex] = newWorker;
+      } catch (spawnError) {
+        // eslint-disable-next-line no-console
+        console.error('[TerrainWorkerPool] Failed to respawn worker:', spawnError);
+      }
+    }
   }
 
   /**

--- a/geoimage/src/workers/TerrainWorkerPool.ts
+++ b/geoimage/src/workers/TerrainWorkerPool.ts
@@ -6,7 +6,7 @@
  * to avoid expensive worker creation/destruction during deck.gl layer recreations.
  */
 
-// @ts-ignore - The import statement will be handled by both Rollup (web-worker: prefix)
+// @ts-expect-error - The import statement will be handled by both Rollup (web-worker: prefix)
 // and our Vite plugin (web-worker: → ?worker conversion)
 import TerrainWorker from 'web-worker:./terrain.worker.ts';
 
@@ -17,7 +17,9 @@ interface MeshResult {
 }
 
 interface PendingTask {
+  // eslint-disable-next-line no-unused-vars
   resolve: (result: MeshResult) => void;
+  // eslint-disable-next-line no-unused-vars
   reject: (error: Error) => void;
   aborted: boolean;
   worker: Worker; // ← Track which worker owns this task for correct abort routing
@@ -60,7 +62,6 @@ class TerrainWorkerPool {
       this.workers.push(worker);
     }
 
-    console.log(`[TerrainWorkerPool] Initialized with ${size} workers`);
   }
 
   /**
@@ -153,9 +154,9 @@ class TerrainWorkerPool {
     }
   }
 
+  // eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars
   private handleWorkerError(e: ErrorEvent) {
-    console.error('[TerrainWorkerPool] Worker error:', e.message);
-    // Global worker errors are rare; log for debugging
+    // Global worker errors are rare; errors are already handled in handleWorkerMessage
   }
 
   /**
@@ -167,7 +168,6 @@ class TerrainWorkerPool {
     this.workers.forEach(w => w.terminate());
     this.workers = [];
     this.pendingTasks.clear();
-    console.log('[TerrainWorkerPool] Terminated');
   }
 }
 

--- a/geoimage/src/workers/TerrainWorkerPool.ts
+++ b/geoimage/src/workers/TerrainWorkerPool.ts
@@ -1,0 +1,199 @@
+/**
+ * Pool of Web Workers for parallel terrain tessellation.
+ * Distributes work across multiple workers based on CPU core count.
+ *
+ * SINGLETON PATTERN: One global pool is shared across all CogTiles instances
+ * to avoid expensive worker creation/destruction during deck.gl layer recreations.
+ */
+
+// @ts-ignore - The import statement will be handled by both Rollup (web-worker: prefix)
+// and our Vite plugin (web-worker: → ?worker conversion)
+import TerrainWorker from 'web-worker:./terrain.worker.ts';
+
+interface MeshResult {
+  vertices: Uint16Array | Float64Array; // Martini → Uint16Array, Delatin → Float64Array
+  triangles: Uint32Array;
+  terrain: Float32Array; // ← Transferred back from worker
+}
+
+interface PendingTask {
+  resolve: (result: MeshResult) => void;
+  reject: (error: Error) => void;
+  aborted: boolean;
+  worker: Worker; // ← Track which worker owns this task for correct abort routing
+}
+
+export interface ComputeMeshOptions {
+  terrain: Float32Array;
+  meshMaxError: number;
+  tesselator: 'martini' | 'delatin';
+  width: number;
+  height: number;
+  signal?: AbortSignal;
+}
+
+/**
+ * Manages a pool of terrain tessellation workers.
+ * Automatically scales to CPU core count (capped at 8 for memory safety).
+ */
+class TerrainWorkerPool {
+  private workers: Worker[] = [];
+  private pendingTasks = new Map<string, PendingTask>();
+  private taskCounter = 0;
+  private roundRobinIndex = 0;
+
+  constructor(poolSize?: number) {
+    // Default to CPU core count, fallback to 4, cap at 8 to prevent memory exhaustion
+    const defaultSize = Math.min(navigator.hardwareConcurrency || 4, 8);
+
+    // On low-memory devices (<4GB), use only 2 workers to avoid OOM
+    const memoryAdjustedSize = (navigator as any).deviceMemory && (navigator as any).deviceMemory < 4
+      ? 2
+      : defaultSize;
+
+    const size = poolSize ?? memoryAdjustedSize;
+
+    for (let i = 0; i < size; i++) {
+      const worker = new TerrainWorker();
+      worker.onmessage = this.handleWorkerMessage.bind(this);
+      worker.onerror = this.handleWorkerError.bind(this);
+      this.workers.push(worker);
+    }
+
+    console.log(`[TerrainWorkerPool] Initialized with ${size} workers`);
+  }
+
+  /**
+   * Compute terrain mesh using the worker pool.
+   * Returns a Promise that resolves with the mesh data.
+   * Supports cancellation via AbortSignal.
+   */
+  async computeMesh(options: ComputeMeshOptions): Promise<MeshResult> {
+    const { terrain, meshMaxError, tesselator, width, height, signal } = options;
+
+    // Check if already aborted
+    if (signal?.aborted) {
+      throw new Error('Task aborted before dispatch');
+    }
+
+    const taskId = `task_${++this.taskCounter}`;
+
+    return new Promise<MeshResult>((resolve, reject) => {
+      // Pick worker once — used for both dispatch and abort to ensure correct routing
+      const worker = this.getNextWorker();
+      const task: PendingTask = { resolve, reject, aborted: false, worker };
+      this.pendingTasks.set(taskId, task);
+
+      // Handle abort signal
+      if (signal) {
+        signal.addEventListener('abort', () => {
+          task.aborted = true;
+          this.pendingTasks.delete(taskId);
+
+          // Send abort to the same worker that owns this task
+          worker.postMessage({ type: 'abort', taskId });
+
+          reject(new Error('Mesh computation aborted'));
+        }, { once: true });
+      }
+
+      // Transfer terrain buffer ownership to avoid copy
+      // NOTE: After this, `terrain` becomes detached on main thread
+      worker.postMessage(
+        {
+          type: 'computeMesh',
+          taskId,
+          terrain,
+          meshMaxError,
+          tesselator,
+          width,
+          height,
+        },
+        [terrain.buffer] // ← Transferable
+      );
+    });
+  }
+
+  private getNextWorker(): Worker {
+    const worker = this.workers[this.roundRobinIndex];
+    this.roundRobinIndex = (this.roundRobinIndex + 1) % this.workers.length;
+    return worker;
+  }
+
+  private handleWorkerMessage(e: MessageEvent) {
+    const { type, taskId, result, terrain, error } = e.data;
+
+    if (type === 'ready') {
+      // Worker initialization complete (can be ignored)
+      return;
+    }
+
+    const task = this.pendingTasks.get(taskId);
+    if (!task) {
+      // Task was aborted or already resolved
+      return;
+    }
+
+    this.pendingTasks.delete(taskId);
+
+    if (task.aborted) {
+      // Ignore result for aborted task
+      return;
+    }
+
+    if (type === 'meshResult') {
+      // Combine result with terrain that was transferred back
+      task.resolve({
+        vertices: result.vertices,
+        triangles: result.triangles,
+        terrain, // ← Include terrain from message
+      });
+    } else if (type === 'error') {
+      task.reject(new Error(`Worker error: ${error}`));
+    }
+  }
+
+  private handleWorkerError(e: ErrorEvent) {
+    console.error('[TerrainWorkerPool] Worker error:', e.message);
+    // Global worker errors are rare; log for debugging
+  }
+
+  /**
+   * Terminate all workers.
+   * ⚠️ NOTE: Because this is a singleton, terminate() should only be called
+   * on app shutdown, not on individual layer unmount.
+   */
+  terminate() {
+    this.workers.forEach(w => w.terminate());
+    this.workers = [];
+    this.pendingTasks.clear();
+    console.log('[TerrainWorkerPool] Terminated');
+  }
+}
+
+// ─── SINGLETON INSTANCE ───
+// Lazily initialized on first use; shared across all CogTiles instances
+let globalWorkerPool: TerrainWorkerPool | null = null;
+
+/**
+ * Gets the global terrain worker pool, creating it on first use.
+ * All CogTiles instances share this pool to avoid expensive worker churn
+ * during deck.gl layer recreations.
+ */
+export function getGlobalTerrainWorkerPool(): TerrainWorkerPool {
+  if (!globalWorkerPool) {
+    globalWorkerPool = new TerrainWorkerPool();
+  }
+  return globalWorkerPool;
+}
+
+/**
+ * Terminates the global worker pool.
+ * Only call this on app shutdown, not on layer unmount.
+ */
+export function terminateGlobalTerrainWorkerPool() {
+  if (globalWorkerPool) {
+    globalWorkerPool.terminate();
+    globalWorkerPool = null;
+  }
+}

--- a/geoimage/src/workers/TerrainWorkerPool.ts
+++ b/geoimage/src/workers/TerrainWorkerPool.ts
@@ -196,9 +196,14 @@ class TerrainWorkerPool {
    * on app shutdown, not on individual layer unmount.
    */
   terminate() {
+    // Reject all pending tasks before terminating workers
+    this.pendingTasks.forEach(task => {
+      task.reject(new Error('TerrainWorkerPool terminated'));
+    });
+    
+    this.pendingTasks.clear();
     this.workers.forEach(w => w.terminate());
     this.workers = [];
-    this.pendingTasks.clear();
   }
 }
 

--- a/geoimage/src/workers/TerrainWorkerPool.ts
+++ b/geoimage/src/workers/TerrainWorkerPool.ts
@@ -74,7 +74,7 @@ class TerrainWorkerPool {
 
     // Check if already aborted
     if (signal?.aborted) {
-      throw new Error('Task aborted before dispatch');
+      throw new DOMException('Aborted', 'AbortError');
     }
 
     const taskId = `task_${++this.taskCounter}`;
@@ -88,13 +88,18 @@ class TerrainWorkerPool {
       // Handle abort signal
       if (signal) {
         signal.addEventListener('abort', () => {
+          // Guard against late aborts: only process if task still exists
+          if (!this.pendingTasks.has(taskId)) {
+            return;
+          }
+          
           task.aborted = true;
           this.pendingTasks.delete(taskId);
 
           // Send abort to the same worker that owns this task
           worker.postMessage({ type: 'abort', taskId });
 
-          reject(new Error('Mesh computation aborted'));
+          reject(new DOMException('Aborted', 'AbortError'));
         }, { once: true });
       }
 
@@ -198,7 +203,7 @@ class TerrainWorkerPool {
   terminate() {
     // Reject all pending tasks before terminating workers
     this.pendingTasks.forEach(task => {
-      task.reject(new Error('TerrainWorkerPool terminated'));
+      task.reject(new DOMException('Worker pool terminated', 'AbortError'));
     });
     
     this.pendingTasks.clear();

--- a/geoimage/src/workers/terrain.worker.ts
+++ b/geoimage/src/workers/terrain.worker.ts
@@ -1,0 +1,114 @@
+/**
+ * Web Worker for terrain mesh tessellation.
+ * Runs Martini/Delatin algorithms on a background thread to avoid blocking the main thread.
+ */
+
+import Martini from '@mapbox/martini';
+import Delatin from '../core/delatin';
+
+// Message types
+interface ComputeMeshRequest {
+  type: 'computeMesh';
+  taskId: string;
+  terrain: Float32Array;
+  meshMaxError: number;
+  tesselator: 'martini' | 'delatin';
+  width: number;
+  height: number;
+}
+
+interface AbortRequest {
+  type: 'abort';
+  taskId: string;
+}
+
+type WorkerRequest = ComputeMeshRequest | AbortRequest;
+
+interface MeshResult {
+  vertices: Uint16Array;
+  triangles: Uint32Array;
+}
+
+interface ComputeMeshResponse {
+  type: 'meshResult';
+  taskId: string;
+  result: MeshResult;
+  terrain: Float32Array; // ← Add terrain to response
+}
+
+// Track aborted tasks to avoid sending results for cancelled work
+const abortedTasks = new Map<string, boolean>();
+
+self.onmessage = (e: MessageEvent<WorkerRequest>) => {
+  const data = e.data;
+
+  if (data.type === 'abort') {
+    // Mark task as aborted; if it's still computing, we'll skip the response
+    abortedTasks.set(data.taskId, true);
+    return;
+  }
+
+  if (data.type === 'computeMesh') {
+    const { taskId, terrain, meshMaxError, tesselator, width, height } = data;
+
+    let mesh: MeshResult;
+
+    try {
+      if (tesselator === 'delatin') {
+        // Delatin tessellation
+        const tin = new Delatin(terrain, width, height);
+        tin.run(meshMaxError);
+        // @ts-expect-error: Delatin instance properties 'coords' and 'triangles' are not explicitly typed in the library port
+        const { coords, triangles } = tin;
+        // coords is a plain array — convert to Float64Array so it has .buffer for transfer
+        const verticesTyped = Float64Array.from(coords);
+        const trianglesTyped = Uint32Array.from(triangles);
+        mesh = {
+          vertices: verticesTyped as any,
+          triangles: trianglesTyped,
+        };
+      } else {
+        // Martini tessellation (default)
+        const gridSize = width === 257 ? 257 : width + 1; // Only add 1 if width is not already 2^n+1
+        const martini = new Martini(gridSize);
+        const tile = martini.createTile(terrain);
+        mesh = tile.getMesh(meshMaxError);
+      }
+
+      // Only send result if not aborted
+      if (!abortedTasks.get(taskId)) {
+        const response: ComputeMeshResponse = {
+          type: 'meshResult',
+          taskId,
+          result: mesh,
+          terrain, // ← CRITICAL: Return terrain buffer to main thread
+        };
+
+        // Transfer ownership of ALL buffers back to main thread (zero-copy roundtrip)
+        // This avoids meshTerrain.slice() allocation on main thread
+        self.postMessage(response, {
+          transfer: [
+            mesh.vertices.buffer,
+            mesh.triangles.buffer,
+            terrain.buffer, // ← Transfer terrain back
+          ],
+        } as StructuredSerializeOptions);
+      }
+    } catch (error) {
+      // Only report errors for non-aborted tasks
+      if (!abortedTasks.get(taskId)) {
+        self.postMessage({
+          type: 'error',
+          taskId,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
+    } finally {
+      // Clean up abort tracking
+      abortedTasks.delete(taskId);
+    }
+  }
+};
+
+// Signal that worker is ready
+self.postMessage({ type: 'ready' });

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "eslint": "^9.39.3",
     "eslint-plugin-react": "^7.37.5",
     "globals": "^17.4.0",
+    "rollup-plugin-web-worker-loader": "^1.7.0",
     "semantic-release": "^25.0.3",
     "typescript": "^6.0.2",
     "typescript-eslint": "^8.57.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5497,6 +5497,7 @@ __metadata:
     eslint: "npm:^9.39.3"
     eslint-plugin-react: "npm:^7.37.5"
     globals: "npm:^17.4.0"
+    rollup-plugin-web-worker-loader: "npm:^1.7.0"
     semantic-release: "npm:^25.0.3"
     typescript: "npm:^6.0.2"
     typescript-eslint: "npm:^8.57.2"
@@ -8994,6 +8995,15 @@ __metadata:
     pacote: "npm:^15.1.1"
     terser: "npm:^5.6.0"
   checksum: 10c0/03711dadab884e2eb5cc67564477efe8bc10f92811684bfebfa959996b525d3055dd1f3891c611cbceb469a71c1c5a176180ee3046b8f367f4a6328b631f6388
+  languageName: node
+  linkType: hard
+
+"rollup-plugin-web-worker-loader@npm:^1.7.0":
+  version: 1.7.0
+  resolution: "rollup-plugin-web-worker-loader@npm:1.7.0"
+  peerDependencies:
+    rollup: ^1.9.2 || ^2.0.0 || ^3.0.0 || ^4.0.0
+  checksum: 10c0/c854841934e8865b30d5ec4ab605228e476d72aa19c004612fab11603fafc76482985a9cb96d6f627eeb343410253742b5c3d159cdf7a478baf29ca1d9cd440e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# feat: move terrain tessellation to Web Worker pool

## Summary
This PR moves terrain mesh tessellation (Martini/Delatin) to background Web Workers to prevent main thread blocking when loading multiple terrain tiles. Resolves performance issues on Windows with 16+ concurrent tile loads and improves responsiveness across all platforms.

## Major Features / Changes
1. **Web Worker Pool Infrastructure**: New `TerrainWorkerPool` singleton manages a CPU core-aware pool of workers (cap: 8) with round-robin task distribution and automatic memory scaling for low-end devices (<4GB).

2. **Worker Implementation**: `terrain.worker.ts` handles Martini/Delatin tessellation with support for cancellation via `AbortSignal` and zero-copy buffer transfer for mesh data.

3. **Integration**: `TerrainGenerator` now delegates mesh computation to the worker pool; pool is initialized lazily in `CogTiles` and exposed for optional app-level cleanup via `terminateGlobalTerrainWorkerPool()`.

4. **Build Tooling**: Added `rollup-plugin-web-worker-loader` for seamless worker bundling; Vite plugin converts `web-worker:` imports to `?worker` syntax for local dev server.

5. **Lint Fixes**: Fixed ESLint errors including `@ts-ignore` → `@ts-expect-error`, removed unused imports and console statements.

## Security & Maintenance
- Dependencies added: `rollup-plugin-web-worker-loader@^1.7.0`
- No breaking changes to public API
- All existing layer props and options preserved

## Notes
- Worker pool is a singleton shared across all `CogTiles` instances to avoid expensive worker churn
- Automatic cleanup on app shutdown recommended via `terminateGlobalTerrainWorkerPool()`
- Low-memory device detection (<4GB) automatically reduces worker count to 2
- All mesh computation now offloaded; main thread blocked during rendering only